### PR TITLE
feat: Spearbit fixes (SC-668)

### DIFF
--- a/src/ALMProxy.sol
+++ b/src/ALMProxy.sol
@@ -30,9 +30,9 @@ contract ALMProxy is IALMProxy, AccessControl {
     /**********************************************************************************************/
 
     function doCall(address target, bytes memory data)
-        external payable override onlyRole(CONTROLLER) returns (bytes memory result)
+        external override onlyRole(CONTROLLER) returns (bytes memory result)
     {
-        result = target.functionCallWithValue(data, msg.value);
+        result = target.functionCall(data);
     }
 
     function doCallWithValue(address target, bytes memory data, uint256 value)
@@ -42,7 +42,7 @@ contract ALMProxy is IALMProxy, AccessControl {
     }
 
     function doDelegateCall(address target, bytes memory data)
-        external payable override onlyRole(CONTROLLER) returns (bytes memory result)
+        external override onlyRole(CONTROLLER) returns (bytes memory result)
     {
         result = target.functionDelegateCall(data);
     }

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -43,9 +43,7 @@ contract ForeignController is AccessControl {
     IPSM3       public immutable psm;
     IRateLimits public immutable rateLimits;
 
-    IERC20 public immutable usds;
     IERC20 public immutable usdc;
-    IERC20 public immutable susds;
 
     bool public active;
 
@@ -60,9 +58,7 @@ contract ForeignController is AccessControl {
         address proxy_,
         address rateLimits_,
         address psm_,
-        address usds_,
         address usdc_,
-        address susds_,
         address cctp_
     ) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin_);
@@ -70,12 +66,8 @@ contract ForeignController is AccessControl {
         proxy      = IALMProxy(proxy_);
         rateLimits = IRateLimits(rateLimits_);
         psm        = IPSM3(psm_);
-
-        usds  = IERC20(usds_);
-        usdc  = IERC20(usdc_);
-        susds = IERC20(susds_);
-
-        cctp = ICCTPLike(cctp_);
+        usdc       = IERC20(usdc_);
+        cctp       = ICCTPLike(cctp_);
 
         active = true;
     }

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
-import { console } from "forge-std/console.sol";
-
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
 import { AccessControl } from "openzeppelin-contracts/contracts/access/AccessControl.sol";
@@ -85,7 +83,6 @@ contract ForeignController is AccessControl {
     }
 
     modifier rateLimited(bytes32 key, uint256 amount) {
-        console.log("Domain key 1: %s", uint256(key));
         rateLimits.triggerRateLimitDecrease(key, amount);
         _;
     }

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -243,6 +243,8 @@ contract MainnetController is AccessControl {
     /*** Relayer PSM functions                                                                  ***/
     /**********************************************************************************************/
 
+    // NOTE: The param `usdcAmount` is denominated in 1e6 precision to match how PSM uses
+    //       USDC precision for both `buyGemNoFee` and `sellGemNoFee`
     function swapUSDSToUSDC(uint256 usdcAmount)
         external onlyRole(RELAYER) isActive rateLimited(LIMIT_USDS_TO_USDC, usdcAmount)
     {

--- a/src/RateLimitHelpers.sol
+++ b/src/RateLimitHelpers.sol
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
-import { console } from "forge-std/console.sol";
-
 library RateLimitHelpers {
 
     function makeAssetKey(bytes32 key, address asset) internal pure returns (bytes32) {
         return keccak256(abi.encode(key, asset));
     }
 
-    function makeDomainKey(bytes32 key, uint32 domain) internal view returns (bytes32) {
-        console.log("key"   , uint256(key));
-        console.log("domain", uint256(domain));
+    function makeDomainKey(bytes32 key, uint32 domain) internal pure returns (bytes32) {
         return keccak256(abi.encode(key, domain));
     }
 

--- a/src/RateLimitHelpers.sol
+++ b/src/RateLimitHelpers.sol
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+import { console } from "forge-std/console.sol";
+
 library RateLimitHelpers {
 
     function makeAssetKey(bytes32 key, address asset) internal pure returns (bytes32) {
         return keccak256(abi.encode(key, asset));
+    }
+
+    function makeDomainKey(bytes32 key, uint32 domain) internal view returns (bytes32) {
+        console.log("key"   , uint256(key));
+        console.log("domain", uint256(domain));
+        return keccak256(abi.encode(key, domain));
     }
 
 }

--- a/src/RateLimits.sol
+++ b/src/RateLimits.sol
@@ -49,7 +49,7 @@ contract RateLimits is IRateLimits, AccessControl {
         emit RateLimitDataSet(key, maxAmount, slope, lastAmount, lastUpdated);
     }
 
-    function setRateLimitData(bytes32 key,uint256 maxAmount,uint256 slope) external override {
+    function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override {
         setRateLimitData(key, maxAmount, slope, maxAmount, block.timestamp);
     }
 

--- a/src/interfaces/IALMProxy.sol
+++ b/src/interfaces/IALMProxy.sol
@@ -17,7 +17,7 @@ interface IALMProxy {
      * @return result The returned data from the call.
      */
     function doCall(address target, bytes calldata data)
-        external payable returns (bytes memory result);
+        external returns (bytes memory result);
 
     /**
      * @dev    This function allows for transferring `value` (ether) along with the call to the target contract.
@@ -38,6 +38,6 @@ interface IALMProxy {
      * @return result The returned data from the delegate call.
      */
     function doDelegateCall(address target, bytes calldata data)
-        external payable returns (bytes memory result);
+        external returns (bytes memory result);
 
 }

--- a/src/interfaces/IALMProxy.sol
+++ b/src/interfaces/IALMProxy.sol
@@ -4,14 +4,12 @@ pragma solidity >=0.8.0;
 interface IALMProxy {
 
     /**
-     * @notice Returns the controller identifier
      * @dev    This function retrieves a constant `bytes32` value that represents the controller.
      * @return The `bytes32` identifier of the controller.
      */
     function CONTROLLER() external view returns (bytes32);
 
     /**
-     * @notice Executes a low-level call to a target contract
      * @dev    Performs a standard call to the specified `target` with the given `data`.
      *         Reverts if the call fails.
      * @param  target The address of the target contract to call.
@@ -22,7 +20,6 @@ interface IALMProxy {
         external payable returns (bytes memory result);
 
     /**
-     * @notice Executes a low-level call with value transfer to a target contract
      * @dev    This function allows for transferring `value` (ether) along with the call to the target contract.
      *         Reverts if the call fails.
      * @param  target The address of the target contract to call.
@@ -34,7 +31,6 @@ interface IALMProxy {
         external payable returns (bytes memory result);
 
     /**
-     * @notice Executes a low-level delegate call to a target contract
      * @dev    This function performs a delegate call to the specified `target`
      *         with the given `data`. Reverts if the call fails.
      * @param  target The address of the target contract to delegate call.

--- a/src/interfaces/IRateLimits.sol
+++ b/src/interfaces/IRateLimits.sol
@@ -103,7 +103,8 @@ interface IRateLimits {
     ) external;
 
     /**
-     * @dev   Sets rate limit data for a specific key.
+     * @dev   Sets rate limit data for a specific key with
+     *        `lastAmount == maxAmount` and `lastUpdated == block.timestamp`.
      * @param key       The identifier for the rate limit.
      * @param maxAmount The maximum allowed amount for the rate limit.
      * @param slope     The slope value used in the rate limit calculation.
@@ -149,7 +150,8 @@ interface IRateLimits {
         external returns (uint256 newLimit);
 
     /**
-     * @dev    Increases the rate limit for a given key up to the maxAmount.
+     * @dev    Increases the rate limit for a given key up to the maxAmount. Does not revert if
+     *         the new rate limit exceeds the maxAmount.
      * @param  key              The identifier for the rate limit.
      * @param  amountToIncrease The amount to increase from the current rate limit.
      * @return newLimit         The updated rate limit after the addition.

--- a/test/base-fork/ForkTestBase.t.sol
+++ b/test/base-fork/ForkTestBase.t.sol
@@ -91,9 +91,7 @@ contract ForkTestBase is Test {
             proxy_      : address(almProxy),
             rateLimits_ : address(rateLimits),
             psm_        : address(psmBase),
-            usds_       : address(usdsBase),
             usdc_       : USDC_BASE,
-            susds_      : address(susdsBase),
             cctp_       : CCTP_MESSENGER_BASE
         });
 

--- a/test/mainnet-fork/CCTPCalls.t.sol
+++ b/test/mainnet-fork/CCTPCalls.t.sol
@@ -109,9 +109,7 @@ contract BaseChainUSDCToCCTPTestBase is ForkTestBase {
             proxy_      : address(foreignAlmProxy),
             rateLimits_ : address(foreignRateLimits),
             psm_        : address(psmBase),
-            usds_       : address(usdsBase),
             usdc_       : USDC_BASE,
-            susds_      : address(susdsBase),
             cctp_       : CCTP_MESSENGER_BASE
         });
 

--- a/test/mainnet-fork/CCTPCalls.t.sol
+++ b/test/mainnet-fork/CCTPCalls.t.sol
@@ -214,8 +214,6 @@ contract BaseChainUSDCToCCTPTestBase is ForkTestBase {
             CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM
         );
 
-        console.log("Domain key 2: %s", uint256(domainKeyEthereum));
-
         // Set up rate limits
         foreignRateLimits.setRateLimitData(domainKeyEthereum,                      5_000_000e6, uint256(1_000_000e6) / 4 hours);
         foreignRateLimits.setRateLimitData(foreignController.LIMIT_USDC_TO_CCTP(), 5_000_000e6, uint256(1_000_000e6) / 4 hours);

--- a/test/mainnet-fork/ForkTestBase.t.sol
+++ b/test/mainnet-fork/ForkTestBase.t.sol
@@ -24,10 +24,12 @@ import { SUsdsInit, SUsdsConfig } from "sdai/deploy/SUsdsInit.sol";
 import { SUsdsInstance }          from "sdai/deploy/SUsdsInstance.sol";
 
 import { Bridge }                from "xchain-helpers/src/testing/Bridge.sol";
+import { CCTPForwarder }         from "xchain-helpers/src/forwarders/CCTPForwarder.sol";
 import { Domain, DomainHelpers } from "xchain-helpers/src/testing/Domain.sol";
 
 import { ALMProxy }          from "src/ALMProxy.sol";
 import { RateLimits }        from "src/RateLimits.sol";
+import { RateLimitHelpers }  from "src/RateLimitHelpers.sol";
 import { MainnetController } from "src/MainnetController.sol";
 
 interface IChainlogLike {
@@ -231,10 +233,16 @@ contract ForkTestBase is DssTest {
 
         rateLimits.grantRole(CONTROLLER, address(mainnetController));
 
+        bytes32 domainKeyBase = RateLimitHelpers.makeDomainKey(
+            mainnetController.LIMIT_USDC_TO_DOMAIN(),
+            CCTPForwarder.DOMAIN_ID_CIRCLE_BASE
+        );
+
         // Setup rate limits to be 1m / 4 hours recharge and 5m max
         rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_MINT(),    5_000_000e18, uint256(1_000_000e18) / 4 hours);
         rateLimits.setRateLimitData(mainnetController.LIMIT_USDS_TO_USDC(), 5_000_000e6,  uint256(1_000_000e6)  / 4 hours);
         rateLimits.setRateLimitData(mainnetController.LIMIT_USDC_TO_CCTP(), 5_000_000e6,  uint256(1_000_000e6)  / 4 hours);
+        rateLimits.setRateLimitData(domainKeyBase,                          5_000_000e6,  uint256(1_000_000e6)  / 4 hours);
 
         IBufferLike(ilkInst.buffer).approve(usdsInst.usds, address(almProxy), type(uint256).max);
 

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -87,9 +87,7 @@ contract ForeignControllerAdminTests is UnitTestBase {
             makeAddr("almProxy"),
             makeAddr("rateLimits"),
             makeAddr("psm"),
-            makeAddr("usds"),
             makeAddr("usdc"),
-            makeAddr("susds"),
             makeAddr("cctp")
         );
     }

--- a/test/unit/controllers/Constructor.t.sol
+++ b/test/unit/controllers/Constructor.t.sol
@@ -44,6 +44,9 @@ contract MainnetControllerConstructorTests is UnitTestBase {
         assertEq(address(mainnetController.usdc()),       makeAddr("usdc"));  // Gem param in MockPSM
         assertEq(address(mainnetController.usds()),       makeAddr("usds"));  // Usds param in MockSUsds
 
+        assertEq(mainnetController.psmTo18ConversionFactor(), psm.to18ConversionFactor());
+        assertEq(mainnetController.psmTo18ConversionFactor(), 1e12);
+
         assertEq(mainnetController.active(), true);
     }
 

--- a/test/unit/controllers/Constructor.t.sol
+++ b/test/unit/controllers/Constructor.t.sol
@@ -54,9 +54,7 @@ contract ForeignControllerConstructorTests is UnitTestBase {
     address almProxy   = makeAddr("almProxy");
     address rateLimits = makeAddr("rateLimits");
     address cctp       = makeAddr("cctp");
-    address usds       = makeAddr("usds");
     address psm        = makeAddr("psm");
-    address susds      = makeAddr("susds");
     address usdc       = makeAddr("usdc");
 
     function test_constructor() public {
@@ -65,9 +63,7 @@ contract ForeignControllerConstructorTests is UnitTestBase {
             almProxy,
             rateLimits,
             psm,
-            usds,
             usdc,
-            susds,
             cctp
         );
 
@@ -76,9 +72,7 @@ contract ForeignControllerConstructorTests is UnitTestBase {
         assertEq(address(foreignController.proxy()),      almProxy);
         assertEq(address(foreignController.rateLimits()), rateLimits);
         assertEq(address(foreignController.psm()),        psm);
-        assertEq(address(foreignController.usds()),       usds);   // asset0 param in MockPSM3
         assertEq(address(foreignController.usdc()),       usdc);   // asset1 param in MockPSM3
-        assertEq(address(foreignController.susds()),      susds);  // asset2 param in MockPSM3
         assertEq(address(foreignController.cctp()),       cctp);
 
         assertEq(foreignController.active(), true);

--- a/test/unit/controllers/Freeze.t.sol
+++ b/test/unit/controllers/Freeze.t.sol
@@ -144,9 +144,7 @@ contract ForeignControllerFreezeTest is ControllerFreezeTests {
             makeAddr("almProxy"),
             makeAddr("rateLimits"),
             address(psm3),
-            usds,
             usdc,
-            susds,
             makeAddr("cctp")
         )));
 
@@ -170,9 +168,7 @@ contract ForeignControllerReactivateTest is ControllerReactivateTests {
             makeAddr("almProxy"),
             makeAddr("rateLimits"),
             address(psm3),
-            usds,
             usdc,
-            susds,
             makeAddr("cctp")
         )));
 

--- a/test/unit/mocks/MockPSM.sol
+++ b/test/unit/mocks/MockPSM.sol
@@ -5,6 +5,8 @@ contract MockPSM {
 
     address public gem;
 
+    uint256 public to18ConversionFactor = 1e12;
+
     constructor(address _gem) {
         gem = _gem;
     }

--- a/test/unit/proxy/DoCall.t.sol
+++ b/test/unit/proxy/DoCall.t.sol
@@ -74,18 +74,6 @@ contract ALMProxyDoCallTests is ALMProxyCallTestBase {
         assertEq(abi.decode(returnData, (uint256)), 84);
     }
 
-    function test_doCall_msgValue() public {
-        vm.deal(controller, 1e18);
-
-        // ALM Proxy is msg.sender, target emits the event, msg.value is sent to target
-        vm.expectEmit(target);
-        emit ExampleEvent(exampleAddress, 42, 84, address(almProxy), 1e18);
-        vm.prank(controller);
-        bytes memory returnData = almProxy.doCall{value: 1e18}(target, data);
-
-        assertEq(abi.decode(returnData, (uint256)), 84);
-    }
-
 }
 
 contract ALMProxyDoCallWithValueFailureTests is ALMProxyCallTestBase {
@@ -182,18 +170,6 @@ contract ALMProxyDoDelegateCallTests is ALMProxyCallTestBase {
         emit ExampleEvent(exampleAddress, 42, 84, controller, 0);
         vm.prank(controller);
         bytes memory returnData = almProxy.doDelegateCall(target, data);
-
-        assertEq(abi.decode(returnData, (uint256)), 84);
-    }
-
-    function test_doDelegateCall_msgValue() public {
-        vm.deal(controller, 1e18);
-
-        // L1 Controller is msg.sender, almProxy emits the event, msg.value sent to proxy
-        vm.expectEmit(address(almProxy));
-        emit ExampleEvent(exampleAddress, 42, 84, controller, 1e18);
-        vm.prank(controller);
-        bytes memory returnData = almProxy.doDelegateCall{value: 1e18}(target, data);
 
         assertEq(abi.decode(returnData, (uint256)), 84);
     }


### PR DESCRIPTION
Addresses comments from spearbit:

https://github.com/spearbit-audits/reviews-maker-0916/issues/7 (`doCall` update, removing `payable` from `doCall` and `doDelegateCall`, removing their corresponding tests)
https://github.com/spearbit-audits/reviews-maker-0916/issues/9 (`to18ConversionFactor` immutable)
https://github.com/spearbit-audits/reviews-maker-0916/issues/10 (Various comment updates, slightly different from suggestions)
https://github.com/spearbit-audits/reviews-maker-0916/issues/11 (Removing USDS and sUSDS from foreignController)
https://github.com/spearbit-audits/reviews-maker-0916/issues/12 (Adding domain specific rate limits and tests)
https://github.com/spearbit-audits/reviews-maker-0916/issues/13 (Add comment about `usdcAmount`)

Also includes a formatting change in RateLimits.sol