### PR TITLE
feat: Add PSM refill on swap (SC-683)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "lib/sdai"]
 	path = lib/sdai
 	url = https://github.com/makerdao/sdai
-[submodule "lib/dss-lite-psm"]
-	path = lib/dss-lite-psm
-	url = https://github.com/makerdao/dss-lite-psm

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/sdai"]
 	path = lib/sdai
 	url = https://github.com/makerdao/sdai
+[submodule "lib/dss-lite-psm"]
+	path = lib/dss-lite-psm
+	url = https://github.com/makerdao/dss-lite-psm

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -293,7 +293,7 @@ contract MainnetController is AccessControl {
         // Max USDC that can be swapped to DAI in one call
         uint256 limit = dai.balanceOf(address(psm)) / psmTo18ConversionFactor;
 
-        if (usdcAmount < limit) {
+        if (usdcAmount <= limit) {
             _swapUSDCToDAI(usdcAmount);
         } else {
             uint256 remainingUsdcToSwap = usdcAmount;

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -297,25 +297,25 @@ contract MainnetController is AccessControl {
         if (daiAmount < psmDaiBalance) {
             _swapUSDCToDAI(usdcAmount);
         } else {
-            uint256 remainingPsmDai = daiAmount;
+            uint256 remainingDaiToSwap = daiAmount;
 
             // Refill the PSM with DAI as many times as needed to get to the full `usdcAmount`.
             // If the PSM cannot be filled with the full amount, psm.fill() will revert
             // with `DssLitePsm/nothing-to-fill` since rush() will return 0.
             // This is desired behavior because this function should only succeed if the full
             // `usdcAmount` can be swapped.
-            while (remainingPsmDai > 0) {
+            while (remainingDaiToSwap > 0) {
                 psm.fill();
 
                 psmDaiBalance = dai.balanceOf(address(psm));
 
-                uint256 swapAmount = remainingPsmDai < psmDaiBalance
-                    ? remainingPsmDai
+                uint256 swapAmount = remainingDaiToSwap < psmDaiBalance
+                    ? remainingDaiToSwap
                     : psmDaiBalance;
 
                 _swapUSDCToDAI(swapAmount / psmTo18ConversionFactor);
 
-                remainingPsmDai -= swapAmount;
+                remainingDaiToSwap -= swapAmount;
             }
         }
 

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -292,52 +292,31 @@ contract MainnetController is AccessControl {
             abi.encodeCall(usdc.approve, (address(psm), usdcAmount))
         );
 
-        // uint256 psmDaiBalance = dai.balanceOf(address(psm));
+        uint256 psmDaiBalance = dai.balanceOf(address(psm));
 
-        // if (daiAmount < psmDaiBalance) {
-        //     _swapUSDCToDAI(usdcAmount);
-        // } else {
-        //     uint256 remainingDaiToSwap = daiAmount;
-
-        //     // Refill the PSM with DAI as many times as needed to get to the full `usdcAmount`.
-        //     // If the PSM cannot be filled with the full amount, psm.fill() will revert
-        //     // with `DssLitePsm/nothing-to-fill` since rush() will return 0.
-        //     // This is desired behavior because this function should only succeed if the full
-        //     // `usdcAmount` can be swapped.
-        //     while (remainingDaiToSwap > 0) {
-        //         psm.fill();
-
-        //         psmDaiBalance = dai.balanceOf(address(psm));
-
-        //         uint256 swapAmount = remainingDaiToSwap < psmDaiBalance
-        //             ? remainingDaiToSwap
-        //             : psmDaiBalance;
-
-        //         _swapUSDCToDAI(swapAmount / psmTo18ConversionFactor);
-
-        //         remainingDaiToSwap -= swapAmount;
-        //     }
-        // }
-
-        // If amount is larger than limit it must be split into multiple calls
-        uint256 limit = dai.balanceOf(address(psm)) / psmTo18ConversionFactor;
-
-        // Edge case where PSM is empty
-        if (limit == 0) {
-        	psm.fill();
-        	limit = dai.balanceOf(address(psm)) / psmTo18ConversionFactor;
-        }
-
-        while (usdcAmount > limit) {
-            _swapUSDCToDAI(limit);
-            usdcAmount -= limit;
-            psm.fill();
-            limit = dai.balanceOf(address(psm)) / psmTo18ConversionFactor;
-        }
-
-        // Swap remaining amount (if any)
-        if (usdcAmount > 0) {
+        if (daiAmount < psmDaiBalance) {
             _swapUSDCToDAI(usdcAmount);
+        } else {
+            uint256 remainingDaiToSwap = daiAmount;
+
+            // Refill the PSM with DAI as many times as needed to get to the full `usdcAmount`.
+            // If the PSM cannot be filled with the full amount, psm.fill() will revert
+            // with `DssLitePsm/nothing-to-fill` since rush() will return 0.
+            // This is desired behavior because this function should only succeed if the full
+            // `usdcAmount` can be swapped.
+            while (remainingDaiToSwap > 0) {
+                psm.fill();
+
+                psmDaiBalance = dai.balanceOf(address(psm));
+
+                uint256 swapAmount = remainingDaiToSwap < psmDaiBalance
+                    ? remainingDaiToSwap
+                    : psmDaiBalance;
+
+                _swapUSDCToDAI(swapAmount / psmTo18ConversionFactor);
+
+                remainingDaiToSwap -= swapAmount;
+            }
         }
 
         // Approve DAI to DaiUsds migrator from the proxy (assumes the proxy has enough DAI)

--- a/test/mainnet-fork/CCTPCalls.t.sol
+++ b/test/mainnet-fork/CCTPCalls.t.sol
@@ -165,7 +165,7 @@ contract BaseChainUSDCToCCTPTestBase is ForkTestBase {
     function setUp() public override virtual {
         super.setUp();
 
-        destination = getChain("base").createSelectFork(18181500);  // August 8, 2024
+        destination = getChain("base").createSelectFork(20187000);  // September 24, 2024
 
         usdsBase  = IERC20(address(new ERC20Mock()));
         susdsBase = IERC20(address(new ERC20Mock()));
@@ -380,7 +380,7 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
 
         assertEq(usds.allowance(address(almProxy), CCTP_MESSENGER),  0);
 
-        _expectEthereumCCTPEmit(94_773, 1e6);
+        _expectEthereumCCTPEmit(110_048, 1e6);
 
         vm.prank(relayer);
         mainnetController.transferUSDCToCCTP(1e6, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE);
@@ -414,9 +414,9 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
         assertEq(usds.allowance(address(almProxy), CCTP_MESSENGER),  0);
 
         // Will split into 3 separate transactions at max 1m each
-        _expectEthereumCCTPEmit(94_773, 1_000_000e6);
-        _expectEthereumCCTPEmit(94_774, 1_000_000e6);
-        _expectEthereumCCTPEmit(94_775, 900_000e6);
+        _expectEthereumCCTPEmit(110_048, 1_000_000e6);
+        _expectEthereumCCTPEmit(110_049, 1_000_000e6);
+        _expectEthereumCCTPEmit(110_050, 900_000e6);
 
         vm.prank(relayer);
         mainnetController.transferUSDCToCCTP(2_900_000e6, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE);
@@ -486,7 +486,7 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
 
         assertEq(usdsBase.allowance(address(foreignAlmProxy), CCTP_MESSENGER_BASE),  0);
 
-        _expectBaseCCTPEmit(255_141, 1e6);
+        _expectBaseCCTPEmit(287_622, 1e6);
 
         vm.prank(relayer);
         foreignController.transferUSDCToCCTP(1e6, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
@@ -522,9 +522,9 @@ contract USDCToCCTPIntegrationTests is BaseChainUSDCToCCTPTestBase {
         assertEq(usdsBase.allowance(address(foreignAlmProxy), CCTP_MESSENGER_BASE),  0);
 
         // Will split into three separate transactions at max 1m each
-        _expectBaseCCTPEmit(255_141, 1_000_000e6);
-        _expectBaseCCTPEmit(255_142, 1_000_000e6);
-        _expectBaseCCTPEmit(255_143, 600_000e6);
+        _expectBaseCCTPEmit(287_622, 1_000_000e6);
+        _expectBaseCCTPEmit(287_623, 1_000_000e6);
+        _expectBaseCCTPEmit(287_624, 600_000e6);
 
         vm.prank(relayer);
         foreignController.transferUSDCToCCTP(2_600_000e6, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);

--- a/test/mainnet-fork/ForkTestBase.t.sol
+++ b/test/mainnet-fork/ForkTestBase.t.sol
@@ -12,6 +12,8 @@ import {
 
 import { AllocatorDeploy } from "dss-allocator/deploy/AllocatorDeploy.sol";
 
+import { DssLitePsm } from "lib/dss-lite-psm/src/DssLitePsm.sol";
+
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
 import { UsdsDeploy }   from "usds/deploy/UsdsDeploy.sol";
@@ -120,6 +122,8 @@ contract ForkTestBase is DssTest {
     IERC20 usdc;
     ISUsds susds;
 
+    DssLitePsm psm;
+
     address buffer;
     address daiUsds;
     address usdsJoin;
@@ -139,7 +143,7 @@ contract ForkTestBase is DssTest {
     /**********************************************************************************************/
 
     function setUp() public virtual {
-        source = getChain("mainnet").createSelectFork(20484600);  // August 8, 2024
+        source = getChain("mainnet").createSelectFork(20819000);  //  September 24, 2024
 
         dss          = MCD.loadFromChainlog(LOG);
         DAI          = IChainlogLike(LOG).getAddress("MCD_DAI");
@@ -259,6 +263,7 @@ contract ForkTestBase is DssTest {
         usds     = IERC20(address(usdsInst.usds));
         usdsJoin = usdsInst.usdsJoin;
         pocket   = IPSMLike(PSM).pocket();
+        psm      = DssLitePsm(PSM);
         susds    = ISUsds(address(susdsInst.sUsds));
         usdc     = IERC20(USDC);
         vault    = ilkInst.vault;

--- a/test/mainnet-fork/ForkTestBase.t.sol
+++ b/test/mainnet-fork/ForkTestBase.t.sol
@@ -81,13 +81,15 @@ contract ForkTestBase is DssTest {
     uint256 USDC_SUPPLY;
 
     /**********************************************************************************************/
-    /*** Mainnet addresses                                                                      ***/
+    /*** Mainnet addresses/constants                                                            ***/
     /**********************************************************************************************/
 
     address constant CCTP_MESSENGER = 0xBd3fa81B58Ba92a82136038B25aDec7066af3155;
     address constant LOG            = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
     address constant PSM            = 0xf6e72Db5454dd049d0788e411b06CfAF16853042;  // Lite PSM
     address constant SPARK_PROXY    = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
+
+    bytes32 constant PSM_ILK = 0x4c4954452d50534d2d555344432d410000000000000000000000000000000000;
 
     DssInstance dss;  // Mainnet DSS
 

--- a/test/mainnet-fork/ForkTestBase.t.sol
+++ b/test/mainnet-fork/ForkTestBase.t.sol
@@ -12,8 +12,6 @@ import {
 
 import { AllocatorDeploy } from "dss-allocator/deploy/AllocatorDeploy.sol";
 
-import { DssLitePsm } from "lib/dss-lite-psm/src/DssLitePsm.sol";
-
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
 import { UsdsDeploy }   from "usds/deploy/UsdsDeploy.sol";
@@ -45,6 +43,7 @@ interface IBufferLike {
 interface IPSMLike {
     function pocket() external view returns (address);
     function kiss(address) external;
+    function rush() external view returns (uint256);
 }
 
 interface IVaultLike {
@@ -124,7 +123,7 @@ contract ForkTestBase is DssTest {
     IERC20 usdc;
     ISUsds susds;
 
-    DssLitePsm psm;
+    IPSMLike psm;
 
     address buffer;
     address daiUsds;
@@ -265,7 +264,7 @@ contract ForkTestBase is DssTest {
         usds     = IERC20(address(usdsInst.usds));
         usdsJoin = usdsInst.usdsJoin;
         pocket   = IPSMLike(PSM).pocket();
-        psm      = DssLitePsm(PSM);
+        psm      = IPSMLike(PSM);
         susds    = ISUsds(address(susdsInst.sUsds));
         usdc     = IERC20(USDC);
         vault    = ilkInst.vault;

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -128,16 +128,6 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
     }
 
     function test_swapUSDCToUSDS_incompleteFillBoundary() external {
-        assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
-
-        DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
-
-        vm.etch(PSM, address(psmCode).code);
-
-        uint256 fillAmount = psm.rush();
-
-        assertEq(fillAmount, 0);
-
         // The line is just over 2.1 billion, this condition will allow DAI to get minted to get to
         // 2 billion in Art, and then another fill to get to the `line`.
         deal(address(usdc), address(pocket), 1_800_000_000e6);
@@ -165,9 +155,7 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
 
         assertEq(maxSwapAmount, 450_281_089.262716e6);
 
-        deal(address(usdc), address(almProxy), maxSwapAmount + 1);  // Higher than balance of DAI + fillAmount
-
-        // assertEq(Art + fillAmount + expectedFillAmount2, line / 1e27);  // Two fills will increase Art to the debt ceiling
+        deal(address(usdc), address(almProxy), maxSwapAmount + 1);
 
         vm.startPrank(relayer);
         vm.expectRevert("DssLitePsm/nothing-to-fill");
@@ -232,10 +220,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
     function test_swapUSDCToUSDS_partialRefill() external {
         assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
 
-        DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
-
-        vm.etch(PSM, address(psmCode).code);
-
+        // PSM is not fillable at current fork so need to deal USDC
         uint256 fillAmount = psm.rush();
 
         assertEq(fillAmount, 0);
@@ -305,10 +290,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
     function test_swapUSDCToUSDS_multipleRefills() external {
         assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
 
-        DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
-
-        vm.etch(PSM, address(psmCode).code);
-
+        // PSM is not fillable at current fork so need to deal USDC
         uint256 fillAmount = psm.rush();
 
         assertEq(fillAmount, 0);

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -414,8 +414,16 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
 
         deal(address(usdc), address(almProxy), swapAmount);
 
+        uint256 usdsBalanceBefore = usds.balanceOf(address(almProxy));
+
         // NOTE: Doing a low-level call here because if the full amount can't be swapped, it should revert
-        address(mainnetController).call(abi.encodeWithSignature("swapUSDCToUSDS(uint256)", swapAmount));
+        ( bool success, ) = address(mainnetController).call(
+            abi.encodeWithSignature("swapUSDCToUSDS(uint256)", swapAmount)
+        );
+
+        if (success) {
+            assertEq(usds.balanceOf(address(almProxy)), usdsBalanceBefore + swapAmount * 1e12);
+        }
     }
 
 }

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -127,8 +127,63 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
         mainnetController.swapUSDCToUSDS(1e6);
     }
 
-    function test_swapUSDCToUSDS_firstRefillIncomplete() external {}
-    function test_swapUSDCToUSDS_secondfRefillIncomplete() external {}
+    function test_swapUSDCToUSDS_incompleteFillBoundary() external {
+        assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
+
+        DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
+
+        vm.etch(PSM, address(psmCode).code);
+
+        uint256 fillAmount = psm.rush();
+
+        assertEq(fillAmount, 0);
+
+        // The line is just over 2.1 billion, this condition will allow DAI to get minted to get to
+        // 2 billion in Art, and then another fill to get to the `line`.
+        deal(address(usdc), address(pocket), 1_800_000_000e6);
+
+        fillAmount = psm.rush();
+
+        assertEq(fillAmount, 121_680_037.47418e18);  // Only first fill amount
+
+        // NOTE: Art == dai here because rate is 1 for PSM ilk
+        ( uint256 Art,,, uint256 line, ) = dss.vat.ilks(PSM_ILK);
+
+        assertEq(Art,  1_878_319_962.52582e18);
+        assertEq(Art,  2_000_000_000e18 - fillAmount);  // First fill gets art to 2 billion
+        assertEq(line, 2_124_094_563.678406e45);
+
+        // The first fill increases the Art to 2 billion and the USDC balance of the PSM to 2.1 billion.
+        // For the second fill, the USDC balance + buffer option is ~2.3 billion so it instead fills to the line
+        // which is 2.124 billion.
+        uint256 expectedFillAmount2 = line / 1e27 - 2_000_000_000e18;
+
+        assertEq(expectedFillAmount2, 124_094_563.678406e18);
+
+        // Max amount of DAI that can be swapped, converted to USDC precision
+        uint256 maxSwapAmount = (DAI_BAL_PSM + fillAmount + expectedFillAmount2) / 1e12;
+
+        assertEq(maxSwapAmount, 450_281_089.262716e6);
+
+        deal(address(usdc), address(almProxy), maxSwapAmount + 1);  // Higher than balance of DAI + fillAmount
+
+        // assertEq(Art + fillAmount + expectedFillAmount2, line / 1e27);  // Two fills will increase Art to the debt ceiling
+
+        vm.startPrank(relayer);
+        vm.expectRevert("DssLitePsm/nothing-to-fill");
+        mainnetController.swapUSDCToUSDS(maxSwapAmount + 1);
+
+        mainnetController.swapUSDCToUSDS(maxSwapAmount);
+
+        ( Art,,,, ) = dss.vat.ilks(PSM_ILK);
+
+        // Art has now been filled to the debt ceiling and there is no DAI left in the PSM.
+        assertEq(Art, line / 1e27);
+        assertEq(Art, 2_124_094_563.678406e18);
+
+        assertEq(dai.balanceOf(address(PSM)), 0);
+    }
+
 }
 
 contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
@@ -264,7 +319,9 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
 
         fillAmount = psm.rush();
 
-        deal(address(usdc), address(almProxy), 400_000_000e6);  // Higher than balance of DAI
+        assertEq(fillAmount, 121_680_037.47418e18);  // Only first fill amount
+
+        deal(address(usdc), address(almProxy), 400_000_000e6);  // Higher than balance of DAI + fillAmount
 
         assertEq(usds.balanceOf(address(almProxy)),          0);
         assertEq(usds.balanceOf(address(mainnetController)), 0);
@@ -286,7 +343,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         ( uint256 Art,,, uint256 line, ) = dss.vat.ilks(PSM_ILK);
 
         assertEq(Art,  1_878_319_962.52582e18);
-        assertEq(Art,  2_000_000_000e18 - fillAmount);
+        assertEq(Art,  2_000_000_000e18 - fillAmount);  // First fill gets art to 2 billion
         assertEq(line, 2_124_094_563.678406e45);
 
         // The first fill increases the Art to 2 billion and the USDC balance of the PSM to 2.1 billion.
@@ -294,8 +351,9 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         // which is 2.124 billion.
         uint256 expectedFillAmount2 = line / 1e27 - 2_000_000_000e18;
 
-        assertEq(fillAmount,          121_680_037.47418e18);  // Only first fill amount
         assertEq(expectedFillAmount2, 124_094_563.678406e18);
+
+        assertEq(Art + fillAmount + expectedFillAmount2, line / 1e27);  // Two fills will increase Art to the debt ceiling
 
         vm.prank(relayer);
         vm.expectEmit(PSM);

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -217,6 +217,15 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
     }
 
+    /**
+     * Partial
+     * Sam:   [409617] MainnetController::swapUSDCToUSDS(300000000000000 [3e14])
+     * Lucas: [392065] MainnetController::swapUSDCToUSDS(300000000000000 [3e14])
+     *
+     * Full
+     * Lucas: [466658] MainnetController::swapUSDCToUSDS(400000000000000 [4e14])
+     */
+
     function test_swapUSDCToUSDS_partialRefill() external {
         assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
 
@@ -258,8 +267,8 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(Art, 2_000_000_000e18 - fillAmount);
 
         vm.prank(relayer);
-        vm.expectEmit(PSM);
-        emit Fill(fillAmount);
+        // vm.expectEmit(PSM);
+        // emit Fill(fillAmount);
         mainnetController.swapUSDCToUSDS(300_000_000e6);
 
         ( Art,,,, ) = dss.vat.ilks(PSM_ILK);

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -174,7 +174,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
     }
 
-    function test_swapUSDCToUSDS_partialSingleRefill() external {
+    function test_swapUSDCToUSDS_partialRefill() external {
         assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
 
         DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
@@ -247,8 +247,85 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
     }
 
-    function test_swapUSDCToUSDS_exactRefill() external {}
-    function test_swapUSDCToUSDS_multipleRefill() external {}
+    function test_swapUSDCToUSDS_multipleRefills() external {
+        assertEq(DAI_BAL_PSM, 204_506_488.11013e18);
+
+        DssLitePsm psmCode = new DssLitePsm(psm.ilk(), address(psm.gem()), address(psm.daiJoin()), psm.pocket());
+
+        vm.etch(PSM, address(psmCode).code);
+
+        uint256 fillAmount = psm.rush();
+
+        assertEq(fillAmount, 0);
+
+        // The line is just over 2.1 billion, this condition will allow DAI to get minted to get to
+        // 2 billion in Art, and then another fill to get to the `line`.
+        deal(address(usdc), address(pocket), 1_800_000_000e6);
+
+        fillAmount = psm.rush();
+
+        deal(address(usdc), address(almProxy), 400_000_000e6);  // Higher than balance of DAI
+
+        assertEq(usds.balanceOf(address(almProxy)),          0);
+        assertEq(usds.balanceOf(address(mainnetController)), 0);
+        assertEq(usds.totalSupply(),                         0);
+
+        assertEq(dai.balanceOf(address(almProxy)), 0);
+        assertEq(dai.balanceOf(address(PSM)),      DAI_BAL_PSM);
+        assertEq(dai.totalSupply(),                DAI_SUPPLY);
+
+        assertEq(usdc.balanceOf(address(almProxy)),          400_000_000e6);
+        assertEq(usdc.balanceOf(address(mainnetController)), 0);
+        assertEq(usdc.balanceOf(address(pocket)),            1_800_000_000e6);
+
+        assertEq(usds.allowance(address(buffer),   address(vault)),   type(uint256).max);
+        assertEq(usds.allowance(address(almProxy), address(daiUsds)), 0);
+        assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
+
+        // NOTE: Art == dai here because rate is 1 for PSM ilk
+        ( uint256 Art,,, uint256 line, ) = dss.vat.ilks(PSM_ILK);
+
+        assertEq(Art,  1_878_319_962.52582e18);
+        assertEq(Art,  2_000_000_000e18 - fillAmount);
+        assertEq(line, 2_124_094_563.678406e45);
+
+        // The first fill increases the Art to 2 billion and the USDC balance of the PSM to 2.1 billion.
+        // For the second fill, the USDC balance + buffer option is ~2.3 billion so it instead fills to the line
+        // which is 2.124 billion.
+        uint256 expectedFillAmount2 = line / 1e27 - 2_000_000_000e18;
+
+        assertEq(fillAmount,          121_680_037.47418e18);  // Only first fill amount
+        assertEq(expectedFillAmount2, 124_094_563.678406e18);
+
+        vm.prank(relayer);
+        vm.expectEmit(PSM);
+        emit Fill(fillAmount);
+        emit Fill(expectedFillAmount2);
+        mainnetController.swapUSDCToUSDS(400_000_000e6);
+
+        ( Art,,,, ) = dss.vat.ilks(PSM_ILK);
+
+        // Art has now been filled to the debt ceiling.
+        assertEq(Art, line / 1e27);
+        assertEq(Art, 2_124_094_563.678406e18);
+
+        assertEq(usds.balanceOf(address(almProxy)),          400_000_000e18);
+        assertEq(usds.balanceOf(address(mainnetController)), 0);
+        assertEq(usds.totalSupply(),                         400_000_000e18);
+
+        assertEq(dai.balanceOf(address(almProxy)), 0);
+        assertEq(dai.balanceOf(address(PSM)),      DAI_BAL_PSM + fillAmount + expectedFillAmount2 - 400_000_000e18);
+        assertEq(dai.balanceOf(address(PSM)),      50_281_089.262716e18);
+        assertEq(dai.totalSupply(),                DAI_SUPPLY + fillAmount + expectedFillAmount2 - 400_000_000e18);
+
+        assertEq(usdc.balanceOf(address(almProxy)),          0);
+        assertEq(usdc.balanceOf(address(mainnetController)), 0);
+        assertEq(usdc.balanceOf(address(pocket)),            2_200_000_000e6);  // 1.8 billion + 400 million
+
+        assertEq(usds.allowance(address(buffer),   address(vault)),   type(uint256).max);
+        assertEq(usds.allowance(address(almProxy), address(daiUsds)), 0);
+        assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
+    }
 
     function test_swapUSDCToUSDS_rateLimited() external {
         bytes32 key = mainnetController.LIMIT_USDS_TO_USDC();
@@ -261,7 +338,6 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(rateLimits.getCurrentRateLimit(key), 4_000_000e6);
         assertEq(usds.balanceOf(address(almProxy)),   4_000_000e18);
         assertEq(usdc.balanceOf(address(almProxy)),   1_000_000e6);
-
 
         mainnetController.swapUSDCToUSDS(400_000e6);
 

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -132,7 +132,7 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
         // 2 billion in Art, and then another fill to get to the `line`.
         deal(address(usdc), address(pocket), 1_800_000_000e6);
 
-        fillAmount = psm.rush();
+        uint256 fillAmount = psm.rush();
 
         assertEq(fillAmount, 121_680_037.47418e18);  // Only first fill amount
 

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -417,12 +417,12 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         uint256 usdsBalanceBefore = usds.balanceOf(address(almProxy));
 
         // NOTE: Doing a low-level call here because if the full amount can't be swapped, it should revert
+        vm.prank(relayer);
         ( bool success, ) = address(mainnetController).call(
             abi.encodeWithSignature("swapUSDCToUSDS(uint256)", swapAmount)
         );
 
         if (success) {
-            assertTrue(false);
             assertEq(usds.balanceOf(address(almProxy)), usdsBalanceBefore + swapAmount * 1e12);
         }
     }

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -127,6 +127,8 @@ contract MainnetControllerSwapUSDCToUSDSFailureTests is ForkTestBase {
         mainnetController.swapUSDCToUSDS(1e6);
     }
 
+    function test_swapUSDCToUSDS_firstRefillIncomplete() external {}
+    function test_swapUSDCToUSDS_secondfRefillIncomplete() external {}
 }
 
 contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
@@ -169,6 +171,10 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         assertEq(usds.allowance(address(almProxy), address(daiUsds)), 0);
         assertEq(dai.allowance(address(almProxy),  address(PSM)),     0);
     }
+
+    function test_swapUSDCToUSDS_partialRefill() external {}
+    function test_swapUSDCToUSDS_exactRefill() external {}
+    function test_swapUSDCToUSDS_multipleRefill() external {}
 
     function test_swapUSDCToUSDS_rateLimited() external {
         bytes32 key = mainnetController.LIMIT_USDS_TO_USDC();

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -409,5 +409,14 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         vm.stopPrank();
     }
 
+    function testFuzz_swapUSDCToUSDS(uint256 swapAmount) external {
+        swapAmount = _bound(swapAmount, 1e6, 1_000_000_000e6);
+
+        deal(address(usdc), address(almProxy), swapAmount);
+
+        // NOTE: Doing a low-level call here because if the full amount can't be swapped, it should revert
+        address(mainnetController).call(abi.encodeWithSignature("swapUSDCToUSDS(uint256)", swapAmount));
+    }
+
 }
 

--- a/test/mainnet-fork/PsmCalls.t.sol
+++ b/test/mainnet-fork/PsmCalls.t.sol
@@ -422,6 +422,7 @@ contract MainnetControllerSwapUSDCToUSDSTests is ForkTestBase {
         );
 
         if (success) {
+            assertTrue(false);
             assertEq(usds.balanceOf(address(almProxy)), usdsBalanceBefore + swapAmount * 1e12);
         }
     }


### PR DESCRIPTION
NOTE: Had to update the fork block to get higher debt cieling params for the new DSS lite PSM on mainnet so updated some CCTP nonces.