### PR TITLE
feat: Make deploy script changes from CS audit (SC-731)

### DIFF
--- a/deploy/ControllerInit.sol
+++ b/deploy/ControllerInit.sol
@@ -27,6 +27,8 @@ interface IForeignControllerLike is IAccessControl {
 
 interface IPSMLike {
     function kiss(address) external;
+    function totalAssets() external view returns (uint256);
+    function totalShares() external view returns (uint256);
 }
 
 interface IVaultLike {
@@ -248,6 +250,9 @@ library ForeignControllerInit {
         require(address(controller.psm())        == addresses.psm,             "ForeignControllerInit/incorrect-psm");
         require(address(controller.usdc())       == addresses.usdc,            "ForeignControllerInit/incorrect-usdc");
         require(address(controller.cctp())       == addresses.cctpMessenger,   "ForeignControllerInit/incorrect-cctp");
+
+        require(IPSMLike(addresses.psm).totalAssets() >= 1e18, "ForeignControllerInit/psm-totalAssets-not-seeded");
+        require(IPSMLike(addresses.psm).totalShares() >= 1e18, "ForeignControllerInit/psm-totalShares-not-seeded");
 
         // Step 1: Configure ACL permissions for controller and almProxy
 

--- a/deploy/ControllerInit.sol
+++ b/deploy/ControllerInit.sol
@@ -253,6 +253,8 @@ library ForeignControllerInit {
         require(address(controller.usdc())       == addresses.usdc,            "ForeignControllerInit/incorrect-usdc");
         require(address(controller.cctp())       == addresses.cctpMessenger,   "ForeignControllerInit/incorrect-cctp");
 
+        require(controller.active() == true, "ForeignControllerInit/controller-not-active");
+
         require(addresses.oldController != address(controller), "ForeignControllerInit/old-controller-is-new-controller");
 
         require(IPSMLike(addresses.psm).totalAssets() >= 1e18, "ForeignControllerInit/psm-totalAssets-not-seeded");

--- a/deploy/ControllerInit.sol
+++ b/deploy/ControllerInit.sol
@@ -48,6 +48,8 @@ library MainnetControllerInit {
         address relayer;
         address oldController;
         address psm;
+        address vault;
+        address buffer;
         address cctpMessenger;
         address dai;
         address daiUsds;
@@ -66,10 +68,9 @@ library MainnetControllerInit {
     bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
 
     function subDaoInitController(
-        AddressParams        memory params,
-        ControllerInstance   memory controllerInst,
-        AllocatorIlkInstance memory ilkInst,
-        InitRateLimitData    memory data
+        AddressParams      memory params,
+        ControllerInstance memory controllerInst,
+        InitRateLimitData  memory data
     )
         internal
     {
@@ -84,8 +85,8 @@ library MainnetControllerInit {
 
         require(address(controller.proxy())      == controllerInst.almProxy,   "MainnetControllerInit/incorrect-almProxy");
         require(address(controller.rateLimits()) == controllerInst.rateLimits, "MainnetControllerInit/incorrect-rateLimits");
-        require(address(controller.vault())      == ilkInst.vault,             "MainnetControllerInit/incorrect-vault");
-        require(address(controller.buffer())     == ilkInst.buffer,            "MainnetControllerInit/incorrect-buffer");
+        require(address(controller.vault())      == params.vault,              "MainnetControllerInit/incorrect-vault");
+        require(address(controller.buffer())     == params.buffer,             "MainnetControllerInit/incorrect-buffer");
         require(address(controller.psm())        == params.psm,                "MainnetControllerInit/incorrect-psm");
         require(address(controller.daiUsds())    == params.daiUsds,            "MainnetControllerInit/incorrect-daiUsds");
         require(address(controller.cctp())       == params.cctpMessenger,      "MainnetControllerInit/incorrect-cctpMessenger");
@@ -124,10 +125,9 @@ library MainnetControllerInit {
     }
 
     function subDaoInitFull(
-        AddressParams        memory params,
-        ControllerInstance   memory controllerInst,
-        AllocatorIlkInstance memory ilkInst,
-        InitRateLimitData    memory data
+        AddressParams      memory params,
+        ControllerInstance memory controllerInst,
+        InitRateLimitData  memory data
     )
         internal
     {
@@ -149,14 +149,13 @@ library MainnetControllerInit {
         subDaoInitController(
             params,
             controllerInst,
-            ilkInst,
             data
         );
 
         // Step 3: Configure almProxy within the allocation system
 
-        IVaultLike(ilkInst.vault).rely(controllerInst.almProxy);
-        IBufferLike(ilkInst.buffer).approve(params.usds, controllerInst.almProxy, type(uint256).max);
+        IVaultLike(params.vault).rely(controllerInst.almProxy);
+        IBufferLike(params.buffer).approve(params.usds, controllerInst.almProxy, type(uint256).max);
     }
 
     function pauseProxyInit(address psm, address almProxy) internal {
@@ -251,7 +250,6 @@ library ForeignControllerInit {
             almProxy.revokeRole(almProxy.CONTROLLER(), params.oldController);
             rateLimits.revokeRole(rateLimits.CONTROLLER(), params.oldController);
         }
-
 
         // Step 2: Configure all rate limits for controller
 

--- a/deploy/ControllerInit.sol
+++ b/deploy/ControllerInit.sol
@@ -104,6 +104,8 @@ library MainnetControllerInit {
         require(controller.psmTo18ConversionFactor() == 1e12, "MainnetControllerInit/incorrect-psmTo18ConversionFactor");
         require(controller.active()                  == true, "MainnetControllerInit/controller-not-active");
 
+        require(addresses.oldController != address(controller), "MainnetControllerInit/old-controller-is-new-controller");
+
         // Step 2: Configure ACL permissions for controller and almProxy
 
         controller.grantRole(controller.FREEZER(), addresses.freezer);
@@ -250,6 +252,8 @@ library ForeignControllerInit {
         require(address(controller.psm())        == addresses.psm,             "ForeignControllerInit/incorrect-psm");
         require(address(controller.usdc())       == addresses.usdc,            "ForeignControllerInit/incorrect-usdc");
         require(address(controller.cctp())       == addresses.cctpMessenger,   "ForeignControllerInit/incorrect-cctp");
+
+        require(addresses.oldController != address(controller), "ForeignControllerInit/old-controller-is-new-controller");
 
         require(IPSMLike(addresses.psm).totalAssets() >= 1e18, "ForeignControllerInit/psm-totalAssets-not-seeded");
         require(IPSMLike(addresses.psm).totalShares() >= 1e18, "ForeignControllerInit/psm-totalShares-not-seeded");

--- a/deploy/ControllerInit.sol
+++ b/deploy/ControllerInit.sol
@@ -217,8 +217,6 @@ library ForeignControllerInit {
         address psm;
         address cctpMessenger;
         address usdc;
-        address usds;
-        address susds;
     }
 
     bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;

--- a/test/base-fork/DeployAndInit.t.sol
+++ b/test/base-fork/DeployAndInit.t.sol
@@ -199,6 +199,19 @@ contract ForeignControllerDeployAndInitFailureTests is ForeignControllerDeployAn
         wrapper.init(addresses, controllerInst, rateLimitData, mintRecipients);
     }
 
+    function test_init_controllerInactive() external {
+        // Cheating to set this outside of init scripts so that the controller can be frozen
+        vm.startPrank(admin);
+        foreignController.grantRole(FREEZER, freezer);
+
+        vm.startPrank(freezer);
+        foreignController.freeze();
+        vm.stopPrank();
+
+        vm.expectRevert("ForeignControllerInit/controller-not-active");
+        wrapper.init(addresses, controllerInst, rateLimitData, mintRecipients);
+    }
+
     function test_init_oldControllerIsNewController() external {
         addresses.oldController = controllerInst.controller;
 

--- a/test/base-fork/DeployAndInit.t.sol
+++ b/test/base-fork/DeployAndInit.t.sol
@@ -44,9 +44,7 @@ contract ForeignControllerDeployAndInitTestBase is ForkTestBase {
             oldController : address(0),  // Empty
             psm           : address(psmBase),
             cctpMessenger : CCTP_MESSENGER_BASE,
-            usdc          : USDC_BASE,
-            usds          : address(usdsBase),
-            susds         : address(susdsBase)
+            usdc          : USDC_BASE
         });
 
         RateLimitData memory usdcDepositData = RateLimitData({

--- a/test/base-fork/DeployAndInit.t.sol
+++ b/test/base-fork/DeployAndInit.t.sol
@@ -199,6 +199,13 @@ contract ForeignControllerDeployAndInitFailureTests is ForeignControllerDeployAn
         wrapper.init(addresses, controllerInst, rateLimitData, mintRecipients);
     }
 
+    function test_init_oldControllerIsNewController() external {
+        addresses.oldController = controllerInst.controller;
+
+        vm.expectRevert("ForeignControllerInit/old-controller-is-new-controller");
+        wrapper.init(addresses, controllerInst, rateLimitData, mintRecipients);
+    }
+
     function test_init_incorrectUsdcDepositData_unlimitedBoundary() external {
         rateLimitData.usdcDepositData.maxAmount = type(uint256).max;
 

--- a/test/mainnet-fork/DeployAndInit.t.sol
+++ b/test/mainnet-fork/DeployAndInit.t.sol
@@ -20,7 +20,6 @@ contract LibraryWrapper {
     function subDaoInitController(
         MainnetControllerInit.AddressParams     memory params,
         ControllerInstance                      memory controllerInst,
-        AllocatorIlkInstance                    memory ilkInst,
         MainnetControllerInit.InitRateLimitData memory rateLimitData
     )
         external
@@ -28,7 +27,6 @@ contract LibraryWrapper {
         MainnetControllerInit.subDaoInitController(
             params,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -36,7 +34,6 @@ contract LibraryWrapper {
     function subDaoInitFull(
         MainnetControllerInit.AddressParams     memory params,
         ControllerInstance                      memory controllerInst,
-        AllocatorIlkInstance                    memory ilkInst,
         MainnetControllerInit.InitRateLimitData memory rateLimitData
     )
         external
@@ -44,7 +41,6 @@ contract LibraryWrapper {
         MainnetControllerInit.subDaoInitFull(
             params,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -65,6 +61,8 @@ contract MainnetControllerDeployInitTestBase is ForkTestBase {
             relayer       : relayer,
             oldController : address(0),
             psm           : PSM,
+            vault         : ilkInst.vault,
+            buffer        : ilkInst.buffer,
             cctpMessenger : CCTP_MESSENGER,
             dai           : address(dai),
             daiUsds       : address(daiUsds),
@@ -156,7 +154,6 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         wrapper.subDaoInitFull(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -172,7 +169,6 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         wrapper.subDaoInitFull(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -206,12 +202,12 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
     }
 
     function test_init_incorrectVault() external {
-        ilkInst.vault = mismatchAddress;
+        addresses.vault = mismatchAddress;
         _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/incorrect-vault"));
     }
 
     function test_init_incorrectBuffer() external {
-        ilkInst.buffer = mismatchAddress;
+        addresses.buffer = mismatchAddress;
         _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/incorrect-buffer"));
     }
 
@@ -367,7 +363,6 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         wrapper.subDaoInitController(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
 
@@ -375,7 +370,6 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         wrapper.subDaoInitFull(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -384,14 +378,12 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         wrapper.subDaoInitController(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
 
         wrapper.subDaoInitFull(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
     }
@@ -448,7 +440,6 @@ contract MainnetControllerDeployAndInitSuccessTests is MainnetControllerDeployIn
         MainnetControllerInit.subDaoInitFull(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
         vm.stopPrank();
@@ -517,7 +508,6 @@ contract MainnetControllerDeployAndInitSuccessTests is MainnetControllerDeployIn
         MainnetControllerInit.subDaoInitController(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
         vm.stopPrank();
@@ -561,7 +551,6 @@ contract MainnetControllerDeployAndInitSuccessTests is MainnetControllerDeployIn
         MainnetControllerInit.subDaoInitController(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
         vm.stopPrank();
@@ -601,7 +590,6 @@ contract MainnetControllerDeployAndInitSuccessTests is MainnetControllerDeployIn
         MainnetControllerInit.subDaoInitController(
             addresses,
             controllerInst,
-            ilkInst,
             rateLimitData
         );
         vm.stopPrank();

--- a/test/mainnet-fork/DeployAndInit.t.sol
+++ b/test/mainnet-fork/DeployAndInit.t.sol
@@ -270,6 +270,11 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/incorrect-usds"));
     }
 
+    function test_init_oldControllerIsNewController() external {
+        addresses.oldController = controllerInst.controller;
+        _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/old-controller-is-new-controller"));
+    }
+
     // TODO: Skipping conversion factor test and active test, can add later if needed
 
     /**********************************************************************************************/

--- a/test/mainnet-fork/DeployAndInit.t.sol
+++ b/test/mainnet-fork/DeployAndInit.t.sol
@@ -270,12 +270,24 @@ contract MainnetControllerDeployAndInitFailureTests is MainnetControllerDeployIn
         _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/incorrect-usds"));
     }
 
+    function test_init_controllerInactive() external {
+        // Cheating to set this outside of init scripts so that the controller can be frozen
+        vm.startPrank(SPARK_PROXY);
+        mainnetController.grantRole(FREEZER, freezer);
+
+        vm.startPrank(freezer);
+        mainnetController.freeze();
+        vm.stopPrank();
+
+        _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/controller-not-active"));
+    }
+
     function test_init_oldControllerIsNewController() external {
         addresses.oldController = controllerInst.controller;
         _checkBothInitsFail(abi.encodePacked("MainnetControllerInit/old-controller-is-new-controller"));
     }
 
-    // TODO: Skipping conversion factor test and active test, can add later if needed
+    // TODO: Skipping conversion factor test, can add later if needed
 
     /**********************************************************************************************/
     /*** Unlimited `maxAmount` rate limit boundary tests                                        ***/

--- a/test/unit/controllers/Freeze.t.sol
+++ b/test/unit/controllers/Freeze.t.sol
@@ -45,7 +45,6 @@ contract ControllerTestBase is UnitTestBase {
     }
 
     function _setRoles() internal {
-
         // Done with spell by pause proxy
         vm.startPrank(admin);
 


### PR DESCRIPTION
This PR does the following:

1. Removes `AllocatorIlkInstance`, moving buffer and vault addresses to AddressParams struct
2. Rename `params` variable to `addresses` to match tests and make more clear (not from CS)
3. Add `mintRecipient` setting in both init scripts
4. Add sanity check for PSM3 to ensure both `totalAssets` and `totalShares` are greater than or equal to 1e18 (PSM is seeded properly)
5. Validate that oldController is not newController so that role is not granted and revoked on the same address
6. Add active check to foreign controller init, add tests for both inits
7. Remove usds and susds from `AddressParams` struct in ForeignControllerInit