### PR TITLE
fix: Certora [M-01] ERC4626 withdrawal (SC-1212)

### DIFF
--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -457,9 +457,8 @@ contract MainnetController is AccessControlEnumerable {
     function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares) {
         _checkRole(RELAYER);
 
-        shares = IERC4626(token).convertToShares(
-            _redeem(token, IERC4626(token).convertToShares(amount))
-        );
+        shares = IERC4626(token).convertToShares(amount);
+        _redeem(token, shares);
     }
 
     // NOTE: !!! Rate limited at end of function !!!

--- a/test/mainnet-fork/4626Calls.t.sol
+++ b/test/mainnet-fork/4626Calls.t.sol
@@ -193,7 +193,7 @@ contract MainnetControllerWithdrawERC4626FailureTests is SUSDSTestBase {
 
 contract MainnetControllerWithdrawERC4626Tests is SUSDSTestBase {
 
-    function test_withdrawERC4626_test() external {
+    function test_withdrawERC4626() external {
         bytes32 depositKey = RateLimitHelpers.makeAddressKey(
             mainnetController.LIMIT_4626_DEPOSIT(),
             Ethereum.SUSDS
@@ -229,7 +229,7 @@ contract MainnetControllerWithdrawERC4626Tests is SUSDSTestBase {
         assertEq(rateLimits.getCurrentRateLimit(depositKey),  4_999_999e18 + (1e18 - 2));
         assertEq(rateLimits.getCurrentRateLimit(withdrawKey), 5_000_000e18 - (1e18 - 2));
 
-        assertEq(shares, SUSDS_CONVERTED_SHARES - 2);
+        assertEq(shares, SUSDS_CONVERTED_SHARES - 1);
 
         assertEq(usds.balanceOf(address(almProxy)),          1e18 - 2);
         assertEq(usds.balanceOf(address(mainnetController)), 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and expanded ERC4626 tests covering withdrawal success/failure, zero-max-amount, and rounding edge cases; updated assertions for balances, totals, and rate-limit effects.

* **Refactor**
  * Consolidated redemption/withdrawal flow to centralize asset↔share conversion and unify rate-limit updates, improving consistency around rounding and rate-limit accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->