### PR TITLE
feat: UniswapV4 swap zeroForOne (SC-1259)

### DIFF
--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -712,7 +712,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
 
     function swapUniswapV4(
         bytes32 poolId,
-        address tokenIn,
+        bool    zeroForOne,
         uint128 amountIn,
         uint128 amountOutMin
     )
@@ -724,7 +724,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
             proxy        : address(proxy),
             rateLimits   : address(rateLimits),
             poolId       : poolId,
-            tokenIn      : tokenIn,
+            zeroForOne   : zeroForOne,
             amountIn     : amountIn,
             amountOutMin : amountOutMin,
             maxSlippage  : maxSlippages[address(uint160(uint256(poolId)))]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Uniswap V4 swap function signature: the `tokenIn` address parameter has been replaced with a `zeroForOne` boolean flag to specify swap direction. Users now indicate whether to swap from token0 to token1 (true) or token1 to token0 (false).

* **Tests**
  * Test cases updated to align with the new swap parameter signature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->