### PR TITLE
fix: Missing validation of fee in LayerZero (DEV-1115)

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -335,6 +335,8 @@ contract ForeignController is ReentrancyGuard, AccessControlEnumerable {
 
         MessagingFee memory fee = ILayerZero(oftAddress).quoteSend(sendParams, false);
 
+        require(msg.value >= fee.nativeFee, "FC/insufficient-fee");
+
         proxy.doCallWithValue{value: fee.nativeFee}(
             oftAddress,
             abi.encodeCall(ILayerZero.send, (sendParams, fee, address(proxy))),

--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -335,7 +335,7 @@ contract ForeignController is ReentrancyGuard, AccessControlEnumerable {
 
         MessagingFee memory fee = ILayerZero(oftAddress).quoteSend(sendParams, false);
 
-        require(msg.value >= fee.nativeFee, "FC/insufficient-fee");
+        require(msg.value == fee.nativeFee, "FC/incorrect-fee");
 
         proxy.doCallWithValue{value: fee.nativeFee}(
             oftAddress,

--- a/src/libraries/LayerZeroLib.sol
+++ b/src/libraries/LayerZeroLib.sol
@@ -71,7 +71,7 @@ library LayerZeroLib {
 
         MessagingFee memory fee = ILayerZero(oftAddress).quoteSend(sendParams, false);
 
-        require(msg.value >= fee.nativeFee, "MC/insufficient-fee");
+        require(msg.value == fee.nativeFee, "MC/incorrect-fee");
 
         proxy.doCallWithValue{value: fee.nativeFee}(
             oftAddress,

--- a/src/libraries/LayerZeroLib.sol
+++ b/src/libraries/LayerZeroLib.sol
@@ -71,6 +71,8 @@ library LayerZeroLib {
 
         MessagingFee memory fee = ILayerZero(oftAddress).quoteSend(sendParams, false);
 
+        require(msg.value >= fee.nativeFee, "MC/insufficient-fee");
+
         proxy.doCallWithValue{value: fee.nativeFee}(
             oftAddress,
             abi.encodeCall(ILayerZero.send, (sendParams, fee, address(proxy))),

--- a/test/mainnet-fork/LayerZero.t.sol
+++ b/test/mainnet-fork/LayerZero.t.sol
@@ -181,7 +181,7 @@ contract MainnetControllerTransferLayerZeroFailureTests is MainnetControllerLaye
         );
     }
 
-    function test_transferTokenLayerZero_insufficientFee() external {
+    function test_transferTokenLayerZero_incorrectFee() external {
         vm.startPrank(SPARK_PROXY);
 
         bytes32 target = bytes32(uint256(uint160(makeAddr("layerZeroRecipient"))));
@@ -219,7 +219,7 @@ contract MainnetControllerTransferLayerZeroFailureTests is MainnetControllerLaye
         MessagingFee memory fee = ILayerZero(USDT_OFT).quoteSend(sendParams, false);
 
         vm.prank(relayer);
-        vm.expectRevert("MC/insufficient-fee");
+        vm.expectRevert("MC/incorrect-fee");
         mainnetController.transferTokenLayerZero{value: fee.nativeFee - 1}(
             USDT_OFT,
             10_000_000e6,
@@ -594,7 +594,7 @@ contract ForeignControllerTransferLayerZeroFailureTests is ArbitrumChainLayerZer
         );
     }
 
-    function test_transferTokenLayerZero_insufficientFee() external {
+    function test_transferTokenLayerZero_incorrectFee() external {
         vm.startPrank(SPARK_EXECUTOR);
 
         bytes32 target = bytes32(uint256(uint160(makeAddr("layerZeroRecipient"))));
@@ -635,7 +635,7 @@ contract ForeignControllerTransferLayerZeroFailureTests is ArbitrumChainLayerZer
         MessagingFee memory fee = ILayerZero(USDT_OFT).quoteSend(sendParams, false);
 
         vm.prank(relayer);
-        vm.expectRevert("FC/insufficient-fee");
+        vm.expectRevert("FC/incorrect-fee");
         foreignController.transferTokenLayerZero{value: fee.nativeFee - 1}(
             USDT_OFT,
             10_000_000e6,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-execution validation to ensure sufficient Ether is provided to cover LayerZero protocol transfer fees before transactions are processed. This prevents failed transactions and improves user experience by catching insufficient fee payments early.

* **Tests**
  * Added comprehensive test coverage for insufficient fee scenarios across LayerZero transfer operations to verify proper error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->