### PR TITLE
fix: Prevent OTC buffer rotation when swap in-progress (DEV-1127)

### DIFF
--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -275,7 +275,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
 
         require(exchange != address(0),  "MC/exchange-zero-address");
         require(otcBuffer != address(0), "MC/otcBuffer-zero-address");
-        require(exchange != otcBuffer, "MC/exchange-equals-otcBuffer");
+        require(exchange != otcBuffer,   "MC/exchange-equals-otcBuffer");
 
         OTC storage otc = otcs[exchange];
 

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -1076,7 +1076,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
 
         OTC storage otc = otcs[exchange];
 
-        // Just to check that OTC buffer exists
+        // Its impossible to have zero address buffer because of whitelistedAssets.
         require(isOtcSwapReady(exchange), "MC/last-swap-not-returned");
 
         otc.sent18        = sent18;

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -273,9 +273,9 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
     function setOTCBuffer(address exchange, address otcBuffer) external nonReentrant {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(exchange != address(0),  "MC/exchange-zero-address");
+        require(exchange  != address(0), "MC/exchange-zero-address");
         require(otcBuffer != address(0), "MC/otcBuffer-zero-address");
-        require(exchange != otcBuffer,   "MC/exchange-equals-otcBuffer");
+        require(exchange  != otcBuffer,  "MC/exchange-equals-otcBuffer");
 
         OTC storage otc = otcs[exchange];
 

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -273,11 +273,15 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
     function setOTCBuffer(address exchange, address otcBuffer) external nonReentrant {
         _checkRole(DEFAULT_ADMIN_ROLE);
 
-        require(exchange != address(0), "MC/exchange-zero-address");
-        require(exchange != otcBuffer,  "MC/exchange-equals-otcBuffer");
+        require(exchange != address(0),  "MC/exchange-zero-address");
+        require(otcBuffer != address(0), "MC/otcBuffer-zero-address");
+        require(exchange != otcBuffer, "MC/exchange-equals-otcBuffer");
 
         OTC storage otc = otcs[exchange];
 
+        // Prevent rotating buffer while a swap is pending and not ready
+        require(otc.sentTimestamp == 0 || isOtcSwapReady(exchange), "MC/swap-in-progress");
+ 
         emit OTCBufferSet(exchange, otc.buffer, otcBuffer);
         otc.buffer = otcBuffer;
     }
@@ -1073,7 +1077,6 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
         OTC storage otc = otcs[exchange];
 
         // Just to check that OTC buffer exists
-        require(otc.buffer != address(0), "MC/otc-buffer-not-set");
         require(isOtcSwapReady(exchange), "MC/last-swap-not-returned");
 
         otc.sent18        = sent18;

--- a/test/mainnet-fork/OTCSwaps.t.sol
+++ b/test/mainnet-fork/OTCSwaps.t.sol
@@ -109,11 +109,9 @@ contract MainnetControllerSetOTCBufferFailureTests is MainnetControllerOTCSwapBa
         vm.prank(relayer);
         mainnetController.otcSend(exchange, address(usdt), 5_000_000e6);
 
-        ( address buffer,,,, ) = mainnetController.otcs(exchange);
-
         vm.expectRevert("MC/swap-in-progress");
         vm.prank(Ethereum.SPARK_PROXY);
-        mainnetController.setOTCBuffer(exchange, address(otcBuffer));
+        mainnetController.setOTCBuffer(exchange, makeAddr("new-buffer"));
     }
 
 }

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -247,6 +247,12 @@ contract MainnetControllerSetOTCBufferTests is MainnetControllerAdminTestBase {
         mainnetController.setOTCBuffer(address(0), address(otcBuffer));
     }
 
+    function test_setOTCBuffer_otcBufferZero() external {
+        vm.prank(admin);
+        vm.expectRevert("MC/otcBuffer-zero-address");
+        mainnetController.setOTCBuffer(exchange, address(0));
+    }
+
     function test_setOTCBuffer_exchangeEqualsOTCBuffer() external {
         vm.prank(admin);
         vm.expectRevert("MC/exchange-equals-otcBuffer");
@@ -291,12 +297,6 @@ contract MainnetControllerSetOTCRechargeRateTests is MainnetControllerAdminTestB
             DEFAULT_ADMIN_ROLE
         ));
         mainnetController.setOTCRechargeRate(exchange, uint256(1_000_000e18) / 1 days);
-    }
-
-    function test_setOTCRechargeRate_exchangeZero() external {
-        vm.prank(admin);
-        vm.expectRevert("MC/exchange-zero-address");
-        mainnetController.setOTCRechargeRate(address(0), uint256(1_000_000e18) / 1 days);
     }
 
     function test_setOTCRechargeRate() external {

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -299,6 +299,12 @@ contract MainnetControllerSetOTCRechargeRateTests is MainnetControllerAdminTestB
         mainnetController.setOTCRechargeRate(exchange, uint256(1_000_000e18) / 1 days);
     }
 
+    function test_setOTCRechargeRate_exchangeZero() external {
+        vm.prank(admin);
+        vm.expectRevert("MC/exchange-zero-address");
+        mainnetController.setOTCRechargeRate(address(0), uint256(1_000_000e18) / 1 days);
+    }
+
     function test_setOTCRechargeRate() external {
         ( , uint256 rate18,,, ) = mainnetController.otcs(exchange);
         assertEq(rate18, 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for OTC buffer configuration to reject invalid inputs
  * Added safeguards preventing buffer updates while swaps are in progress

* **Tests**
  * Expanded test coverage for OTC buffer operations during active swaps
  * Removed obsolete test case

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->