### PR TITLE
feat: Make weETHModule an upgradeable proxy (DEV-1149)

### DIFF
--- a/src/WEETHModule.sol
+++ b/src/WEETHModule.sol
@@ -70,9 +70,7 @@ contract WEETHModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     /**********************************************************************************************/
 
     function claimWithdrawal(uint256 requestId) external returns (uint256 ethReceived) {
-        WEETHModuleStorage storage $ = _getWEETHModuleStorage();
-
-        require(msg.sender == $.almProxy, "WeEthModule/invalid-sender");
+        require(msg.sender == almProxy(), "WeEthModule/invalid-sender");
 
         address eETH               = IWEETHLike(Ethereum.WEETH).eETH();
         address liquidityPool      = IEETHLike(eETH).liquidityPool();
@@ -95,7 +93,7 @@ contract WEETHModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         // Wrap ETH to WETH.
         IWETHLike(Ethereum.WETH).deposit{value: ethReceived}();
 
-        IERC20(Ethereum.WETH).safeTransfer($.almProxy, ethReceived);
+        IERC20(Ethereum.WETH).safeTransfer(msg.sender, ethReceived);
     }
 
     function onERC721Received(address, address, uint256, bytes calldata) external returns (bytes4) {

--- a/src/WEETHModule.sol
+++ b/src/WEETHModule.sol
@@ -36,7 +36,6 @@ contract WEETHModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         0x72fb93b69874a05cc16cf86ff69e742007cd0f04a37e31aa1dda9b1c977e8300;
 
     function _getWEETHModuleStorage() internal pure returns (WEETHModuleStorage storage $) {
-        // slither-disable-next-line assembly
         assembly {
             $.slot := _WEETH_MODULE_STORAGE_LOCATION
         }
@@ -96,7 +95,9 @@ contract WEETHModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         IERC20(Ethereum.WETH).safeTransfer(msg.sender, ethReceived);
     }
 
-    function onERC721Received(address, address, uint256, bytes calldata) external returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) 
+        external pure returns (bytes4) 
+    {
         return this.onERC721Received.selector;
     }
 

--- a/src/WeEthModule.sol
+++ b/src/WeEthModule.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
-import { AccessControlEnumerable }  from "openzeppelin-contracts/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IERC20Metadata as IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import { AccessControlEnumerableUpgradeable }
+    from "openzeppelin-contracts-upgradeable/contracts/access/extensions/AccessControlEnumerableUpgradeable.sol";
+
+import { UUPSUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import { Ethereum } from "spark-address-registry/Ethereum.sol";
 
@@ -14,21 +18,28 @@ interface IWithdrawRequestNFTLike {
     function isValid(uint256 requestId) external view returns (bool);
 }
 
-contract WeEthModule is AccessControlEnumerable {
+contract WeEthModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
-    address public immutable almProxy;
+    address public almProxy;
 
     /**********************************************************************************************/
     /*** Initialization                                                                         ***/
     /**********************************************************************************************/
 
-    constructor(address admin, address _almProxy) {
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address admin, address _almProxy) external initializer {
         require(_almProxy != address(0), "WeEthModule/invalid-alm-proxy");
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
         almProxy = _almProxy;
     }
+
+    // Only DEFAULT_ADMIN_ROLE can upgrade the implementation
+    function _authorizeUpgrade(address) internal view override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /**********************************************************************************************/
     /*** External functions                                                                     ***/

--- a/src/WeEthModule.sol
+++ b/src/WeEthModule.sol
@@ -22,6 +22,8 @@ contract WeEthModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
     address public almProxy;
 
+    uint256[49] private __gap;
+
     /**********************************************************************************************/
     /*** Initialization                                                                         ***/
     /**********************************************************************************************/
@@ -32,6 +34,9 @@ contract WeEthModule is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
     function initialize(address admin, address _almProxy) external initializer {
         require(_almProxy != address(0), "WeEthModule/invalid-alm-proxy");
+
+        __AccessControlEnumerable_init();
+        __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 

--- a/test/mainnet-fork/weETH.t.sol
+++ b/test/mainnet-fork/weETH.t.sol
@@ -22,10 +22,6 @@ interface IWithdrawRequestNFTLike {
     function roleRegistry() external view returns (address);
 }
 
-interface IWeEthModuleLike {
-    function initialize(address admin, address _almProxy) external;
-}
-
 contract MainnetControllerWeETHTestBase is ForkTestBase {
 
     IWEETHLike weETH = IWEETHLike(Ethereum.WEETH);

--- a/test/mainnet-fork/weETH.t.sol
+++ b/test/mainnet-fork/weETH.t.sol
@@ -53,14 +53,14 @@ contract MainnetControllerWeETHTestBase is ForkTestBase {
         liquidityPool = ILiquidityPoolLike(IEETHLike(eETH).liquidityPool());
 
         weETHModule = address(
-                new ERC1967Proxy(
-                    address(new WEETHModule()),
-                    abi.encodeCall(
-                        WEETHModule.initialize,
-                        (Ethereum.SPARK_PROXY, address(almProxy))
-                    )
+            new ERC1967Proxy(
+                address(new WEETHModule()),
+                abi.encodeCall(
+                    WEETHModule.initialize,
+                    (Ethereum.SPARK_PROXY, address(almProxy))
                 )
-            );
+            )
+        );
     }
 
     function _getBlock() internal override pure returns (uint256) {

--- a/test/mainnet-fork/weETH.t.sol
+++ b/test/mainnet-fork/weETH.t.sol
@@ -5,7 +5,7 @@ import { ReentrancyGuard } from "../../lib/openzeppelin-contracts/contracts/util
 
 import { ERC1967Proxy } from "../../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import { IWEETHLike, IEETHLike } from "../../src/libraries/WeETHLib.sol";
+import { IWEETHLike, IEETHLike } from "../../src/libraries/WEETHLib.sol";
 
 import { WEETHModule } from "../../src/WEETHModule.sol";
 

--- a/test/unit/WEETHModule.t.sol
+++ b/test/unit/WEETHModule.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.21;
+
+import { ERC1967Proxy } from "../../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { WEETHModule } from "src/WEETHModule.sol";
+
+import { UnitTestBase } from "./UnitTestBase.t.sol";
+
+contract WEETHModuleTestBase is UnitTestBase {
+
+    address almProxy = makeAddr("almProxy");
+
+}
+
+contract WEETHModuleInitializeTest is WEETHModuleTestBase {
+
+    function test_initialize_invalidAdmin() public {
+        address implementation = address(new WEETHModule());
+
+        vm.expectRevert("WEETHModule/invalid-admin");
+        new ERC1967Proxy(
+            implementation,
+            abi.encodeCall(
+                WEETHModule.initialize,
+                (address(0), almProxy)
+            )
+        );
+    }
+
+    function test_initialize_invalidAlmProxy() public {
+        address implementation = address(new WEETHModule());
+
+        vm.expectRevert("WEETHModule/invalid-alm-proxy");
+        new ERC1967Proxy(
+            implementation,
+            abi.encodeCall(
+                WEETHModule.initialize,
+                (admin, address(0))
+            )
+        );
+    }
+
+    function test_initialize_cannotInitializeAgain() public {
+        WEETHModule weethModule = WEETHModule(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(new WEETHModule()),
+                        abi.encodeCall(
+                            WEETHModule.initialize,
+                            (admin, almProxy)
+                        )
+                    )
+                )
+            )
+        );
+
+        vm.expectRevert("InvalidInitialization()");
+        weethModule.initialize(admin, almProxy);
+    }
+
+    function test_initialize_cannotInitializeImplementation() public {
+        WEETHModule implementation = new WEETHModule();
+
+        vm.expectRevert("InvalidInitialization()");
+        implementation.initialize(admin, almProxy);
+    }
+
+    function test_initialize_success() public {
+        WEETHModule weethModule = WEETHModule(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(new WEETHModule()),
+                        abi.encodeCall(
+                            WEETHModule.initialize,
+                            (admin, almProxy)
+                        )
+                    )
+                )
+            )
+        );
+
+        assertEq(weethModule.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
+        assertEq(weethModule.almProxy(),                         almProxy);
+    }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WEETHModule now supports upgradeable architecture, enabling future protocol enhancements.

* **Chores**
  * Migrated module to proxy-based deployment pattern.
  * Updated module initialization and access control mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->