### PR TITLE
feat: Make OTCBuffer Upgradeable (DEV-1158)

### DIFF
--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -13,7 +13,24 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
     using SafeERC20 for IERC20;
 
-    address public almProxy;
+    /**********************************************************************************************/
+    /*** UUPS Storage                                                                           ***/
+    /**********************************************************************************************/
+
+    struct BufferStorage {
+        address almProxy;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("otcBuffer.storage.Buffer")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant _BUFFER_STORAGE_LOCATION =
+        0xa8ff6143ce9b2840ac86932ea3c593f97be7f3f4c76899ca3e385ef6d4c71f00;
+
+    function _getBufferStorage() internal pure returns (BufferStorage storage $) {
+        // slither-disable-next-line assembly
+        assembly {
+            $.slot := _BUFFER_STORAGE_LOCATION
+        }
+    }
 
     /**********************************************************************************************/
     /*** Initialization                                                                         ***/
@@ -32,7 +49,9 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
-        almProxy = almProxy_;
+        BufferStorage storage $ = _getBufferStorage();
+
+        $.almProxy = almProxy_;
     }
 
     // Only DEFAULT_ADMIN_ROLE can upgrade the implementation
@@ -45,7 +64,9 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     function approve(address asset, uint256 allowance)
         external onlyRole(DEFAULT_ADMIN_ROLE)
     {
-        IERC20(asset).forceApprove(almProxy, allowance);
+        BufferStorage storage $ = _getBufferStorage();
+
+        IERC20(asset).forceApprove($.almProxy, allowance);
     }
 
 }

--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -22,15 +22,16 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         _disableInitializers();
     }
 
-    function initialize(address admin, address _almProxy) external initializer {
-        require(_almProxy != address(0), "OTCBuffer/invalid-alm-proxy");
+    function initialize(address admin, address almProxy_) external initializer {
+        require(admin     != address(0), "OTCBuffer/invalid-admin");
+        require(almProxy_ != address(0), "OTCBuffer/invalid-alm-proxy");
 
         __AccessControlEnumerable_init();
         __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
-        almProxy = _almProxy;
+        almProxy = almProxy_;
     }
 
     function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -39,16 +39,16 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         _disableInitializers();  // Avoid initializing in the context of the implementation
     }
 
-    function initialize(address admin, address almProxy) external initializer {
+    function initialize(address admin, address almProxy_) external initializer {
         require(admin     != address(0), "OTCBuffer/invalid-admin");
-        require(almProxy  != address(0), "OTCBuffer/invalid-alm-proxy");
+        require(almProxy_ != address(0), "OTCBuffer/invalid-alm-proxy");
 
         __AccessControlEnumerable_init();
         __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
-        _getOTCBufferStorage().almProxy = almProxy;
+        _getOTCBufferStorage().almProxy = almProxy_;
     }
 
     // Only DEFAULT_ADMIN_ROLE can upgrade the implementation
@@ -61,10 +61,10 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     function approve(address asset, uint256 allowance)
         external onlyRole(DEFAULT_ADMIN_ROLE)
     {
-        IERC20(asset).forceApprove(_getOTCBufferStorage().almProxy, allowance);
+        IERC20(asset).forceApprove(almProxy(), allowance);
     }
 
-    function almProxy() external view returns (address) {
+    function almProxy() public view returns (address) {
         return _getOTCBufferStorage().almProxy;
     }
 

--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -1,27 +1,39 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
-import { AccessControlEnumerable }  from "openzeppelin-contracts/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IERC20Metadata as IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { SafeERC20 }                from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import { UUPSUpgradeable }          from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-contract OTCBuffer is AccessControlEnumerable {
+import { AccessControlEnumerableUpgradeable } 
+    from "openzeppelin-contracts-upgradeable/contracts/access/extensions/AccessControlEnumerableUpgradeable.sol";
+
+contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
 
     using SafeERC20 for IERC20;
 
-    address public immutable almProxy;
+    address public almProxy;
 
     /**********************************************************************************************/
     /*** Initialization                                                                         ***/
     /**********************************************************************************************/
 
-    constructor(address admin, address _almProxy) {
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address admin, address _almProxy) external initializer {
         require(_almProxy != address(0), "OTCBuffer/invalid-alm-proxy");
+
+        __AccessControlEnumerable_init();
+        __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
         almProxy = _almProxy;
     }
+
+    function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /**********************************************************************************************/
     /*** Call functions                                                                         ***/

--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.21;
 
 import { IERC20Metadata as IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { SafeERC20 }                from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import { UUPSUpgradeable }          from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import { UUPSUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import { AccessControlEnumerableUpgradeable } 
     from "openzeppelin-contracts-upgradeable/contracts/access/extensions/AccessControlEnumerableUpgradeable.sol";
@@ -19,7 +20,7 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     /**********************************************************************************************/
 
     constructor() {
-        _disableInitializers();
+        _disableInitializers();  // Avoid initializing in the context of the implementation
     }
 
     function initialize(address admin, address almProxy_) external initializer {
@@ -34,6 +35,7 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         almProxy = almProxy_;
     }
 
+    // Only DEFAULT_ADMIN_ROLE can upgrade the implementation
     function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     /**********************************************************************************************/

--- a/src/OTCBuffer.sol
+++ b/src/OTCBuffer.sol
@@ -17,18 +17,17 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     /*** UUPS Storage                                                                           ***/
     /**********************************************************************************************/
 
-    struct BufferStorage {
+    struct OTCBufferStorage {
         address almProxy;
     }
 
-    // keccak256(abi.encode(uint256(keccak256("otcBuffer.storage.Buffer")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 internal constant _BUFFER_STORAGE_LOCATION =
-        0xa8ff6143ce9b2840ac86932ea3c593f97be7f3f4c76899ca3e385ef6d4c71f00;
+    // keccak256(abi.encode(uint256(keccak256("almController.storage.OTCBuffer")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 internal constant _OTC_BUFFER_STORAGE_LOCATION =
+        0xe0e561841bb6fa9b0b4be53b5b4f5d506ea40664f6db7ecbcf7b6f18935a4f00;
 
-    function _getBufferStorage() internal pure returns (BufferStorage storage $) {
-        // slither-disable-next-line assembly
+    function _getOTCBufferStorage() internal pure returns (OTCBufferStorage storage $) {
         assembly {
-            $.slot := _BUFFER_STORAGE_LOCATION
+            $.slot := _OTC_BUFFER_STORAGE_LOCATION
         }
     }
 
@@ -40,18 +39,16 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
         _disableInitializers();  // Avoid initializing in the context of the implementation
     }
 
-    function initialize(address admin, address almProxy_) external initializer {
+    function initialize(address admin, address almProxy) external initializer {
         require(admin     != address(0), "OTCBuffer/invalid-admin");
-        require(almProxy_ != address(0), "OTCBuffer/invalid-alm-proxy");
+        require(almProxy  != address(0), "OTCBuffer/invalid-alm-proxy");
 
         __AccessControlEnumerable_init();
         __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
 
-        BufferStorage storage $ = _getBufferStorage();
-
-        $.almProxy = almProxy_;
+        _getOTCBufferStorage().almProxy = almProxy;
     }
 
     // Only DEFAULT_ADMIN_ROLE can upgrade the implementation
@@ -64,9 +61,11 @@ contract OTCBuffer is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
     function approve(address asset, uint256 allowance)
         external onlyRole(DEFAULT_ADMIN_ROLE)
     {
-        BufferStorage storage $ = _getBufferStorage();
+        IERC20(asset).forceApprove(_getOTCBufferStorage().almProxy, allowance);
+    }
 
-        IERC20(asset).forceApprove($.almProxy, allowance);
+    function almProxy() external view returns (address) {
+        return _getOTCBufferStorage().almProxy;
     }
 
 }

--- a/test/mainnet-fork/OTCSwaps.t.sol
+++ b/test/mainnet-fork/OTCSwaps.t.sol
@@ -56,7 +56,8 @@ contract MainnetControllerOTCSwapBase is ForkTestBase {
     function setUp() public virtual override {
         super.setUp();
 
-        otcBuffer = OTCBuffer(address(
+        otcBuffer = OTCBuffer(
+            address(
                 new ERC1967Proxy(
                     address(new OTCBuffer()),
                     abi.encodeCall(
@@ -64,7 +65,8 @@ contract MainnetControllerOTCSwapBase is ForkTestBase {
                         (Ethereum.SPARK_PROXY, address(almProxy))
                     )
                 )
-            ));
+            )
+        );
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         otcBuffer.approve(address(usdt), type(uint256).max);

--- a/test/mainnet-fork/OTCSwaps.t.sol
+++ b/test/mainnet-fork/OTCSwaps.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
+import { ERC1967Proxy }                  from "../../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { ERC20Mock }                     from "../../lib/openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20Metadata }                from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IERC20 as OzIERC20, SafeERC20 } from "../../lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -55,7 +56,15 @@ contract MainnetControllerOTCSwapBase is ForkTestBase {
     function setUp() public virtual override {
         super.setUp();
 
-        otcBuffer = new OTCBuffer(Ethereum.SPARK_PROXY, address(almProxy));
+        otcBuffer = OTCBuffer(address(
+                new ERC1967Proxy(
+                    address(new OTCBuffer()),
+                    abi.encodeCall(
+                        OTCBuffer.initialize,
+                        (Ethereum.SPARK_PROXY, address(almProxy))
+                    )
+                )
+            ));
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         otcBuffer.approve(address(usdt), type(uint256).max);

--- a/test/unit/OTCBuffer.t.sol
+++ b/test/unit/OTCBuffer.t.sol
@@ -16,15 +16,17 @@ contract OTCBufferTestBase is UnitTestBase {
     address almProxy = makeAddr("almProxy");
 
     function setUp() public {
-        buffer = OTCBuffer(address(
-                    new ERC1967Proxy(
-                        address(new OTCBuffer()),
-                        abi.encodeCall(
-                            OTCBuffer.initialize,
-                            (admin, almProxy)
-                        )
+        buffer = OTCBuffer(
+            address(
+                new ERC1967Proxy(
+                    address(new OTCBuffer()),
+                    abi.encodeCall(
+                        OTCBuffer.initialize,
+                        (admin, almProxy)
                     )
-                ));
+                )
+            )
+        );
 
         usdt   = new ERC20Mock();
     }
@@ -33,19 +35,38 @@ contract OTCBufferTestBase is UnitTestBase {
 
 contract OTCBufferInitializeTests is OTCBufferTestBase {
 
-    function test_initialize_invalidAlmProxy() public {
+    function test_initialize_invalidAdmin() public {
         address otcBuffer = address(new OTCBuffer());
-        
-        vm.expectRevert("OTCBuffer/invalid-alm-proxy");
-        OTCBuffer(address(
-            new ERC1967Proxy(
-                otcBuffer,
-                abi.encodeCall(
-                    OTCBuffer.initialize,
-                    (admin, address(0))
+
+        vm.expectRevert("OTCBuffer/invalid-admin");
+        OTCBuffer(
+            address(
+                new ERC1967Proxy(
+                    otcBuffer,
+                    abi.encodeCall(
+                        OTCBuffer.initialize,
+                        (address(0), almProxy)
+                    )
                 )
             )
-        ));
+        );
+    }
+
+    function test_initialize_invalidAlmProxy() public {
+        address otcBuffer = address(new OTCBuffer());
+
+        vm.expectRevert("OTCBuffer/invalid-alm-proxy");
+        OTCBuffer(
+            address(
+                new ERC1967Proxy(
+                    otcBuffer,
+                    abi.encodeCall(
+                        OTCBuffer.initialize,
+                        (admin, address(0))
+                    )
+                )
+            )
+        );
     }
 
     function test_initialize() public {
@@ -53,7 +74,8 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
 
         address newAdmin = makeAddr("new-admin");
 
-        OTCBuffer newBuffer = OTCBuffer(address(
+        OTCBuffer newBuffer = OTCBuffer(
+            address(
                 new ERC1967Proxy(
                     address(new OTCBuffer()),
                     abi.encodeCall(
@@ -61,7 +83,8 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
                         (newAdmin, almProxy)
                     )
                 )
-            ));
+            )
+        );
 
         assertEq(newBuffer.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
     }

--- a/test/unit/OTCBuffer.t.sol
+++ b/test/unit/OTCBuffer.t.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
-import { ERC20Mock } from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+import { ERC1967Proxy } from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { ERC20Mock }    from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
 
 import { OTCBuffer } from "src/OTCBuffer.sol";
 
@@ -15,25 +16,52 @@ contract OTCBufferTestBase is UnitTestBase {
     address almProxy = makeAddr("almProxy");
 
     function setUp() public {
-        buffer = new OTCBuffer(admin, almProxy);
+        buffer = OTCBuffer(address(
+                    new ERC1967Proxy(
+                        address(new OTCBuffer()),
+                        abi.encodeCall(
+                            OTCBuffer.initialize,
+                            (admin, almProxy)
+                        )
+                    )
+                ));
+
         usdt   = new ERC20Mock();
     }
 
 }
 
-contract OTCBufferConstructorTest is OTCBufferTestBase {
+contract OTCBufferInitializeTests is OTCBufferTestBase {
 
-    function test_constructor_invalidAlmProxy() public {
+    function test_initialize_invalidAlmProxy() public {
+        address otcBuffer = address(new OTCBuffer());
+        
         vm.expectRevert("OTCBuffer/invalid-alm-proxy");
-        new OTCBuffer(admin, address(0));
+        OTCBuffer(address(
+            new ERC1967Proxy(
+                otcBuffer,
+                abi.encodeCall(
+                    OTCBuffer.initialize,
+                    (admin, address(0))
+                )
+            )
+        ));
     }
 
-    function test_constructor() public {
+    function test_initialize() public {
         assertEq(buffer.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
 
         address newAdmin = makeAddr("new-admin");
 
-        OTCBuffer newBuffer = new OTCBuffer(newAdmin, almProxy);
+        OTCBuffer newBuffer = OTCBuffer(address(
+                new ERC1967Proxy(
+                    address(new OTCBuffer()),
+                    abi.encodeCall(
+                        OTCBuffer.initialize,
+                        (newAdmin, almProxy)
+                    )
+                )
+            ));
 
         assertEq(newBuffer.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
     }

--- a/test/unit/OTCBuffer.t.sol
+++ b/test/unit/OTCBuffer.t.sol
@@ -77,6 +77,7 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
 
     function test_initialize() public {
         assertEq(buffer.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
+        assertEq(buffer.almProxy(),                         almProxy);
 
         address newAdmin = makeAddr("new-admin");
 
@@ -93,6 +94,7 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
         );
 
         assertEq(newBuffer.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
+        assertEq(newBuffer.almProxy(),                            almProxy);
     }
 
 }

--- a/test/unit/OTCBuffer.t.sol
+++ b/test/unit/OTCBuffer.t.sol
@@ -28,7 +28,7 @@ contract OTCBufferTestBase is UnitTestBase {
             )
         );
 
-        usdt   = new ERC20Mock();
+        usdt = new ERC20Mock();
     }
 
 }
@@ -39,15 +39,11 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
         address otcBuffer = address(new OTCBuffer());
 
         vm.expectRevert("OTCBuffer/invalid-admin");
-        OTCBuffer(
-            address(
-                new ERC1967Proxy(
-                    otcBuffer,
-                    abi.encodeCall(
-                        OTCBuffer.initialize,
-                        (address(0), almProxy)
-                    )
-                )
+        new ERC1967Proxy(
+            otcBuffer,
+            abi.encodeCall(
+                OTCBuffer.initialize,
+                (address(0), almProxy)
             )
         );
     }
@@ -56,17 +52,27 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
         address otcBuffer = address(new OTCBuffer());
 
         vm.expectRevert("OTCBuffer/invalid-alm-proxy");
-        OTCBuffer(
-            address(
-                new ERC1967Proxy(
-                    otcBuffer,
-                    abi.encodeCall(
-                        OTCBuffer.initialize,
-                        (admin, address(0))
-                    )
-                )
+        new ERC1967Proxy(
+            otcBuffer,
+            abi.encodeCall(
+                OTCBuffer.initialize,
+                (admin, address(0))
             )
         );
+    }
+
+    function test_initialize_cannotInitializeTwice() public {
+        vm.expectRevert("InvalidInitialization()");
+        buffer.initialize(admin, almProxy);
+    }
+
+    function test_initialize_cannotInitializeImplementation() public {
+        OTCBuffer newBuffer = OTCBuffer(
+            address(new OTCBuffer())
+        );
+
+        vm.expectRevert("InvalidInitialization()");
+        newBuffer.initialize(admin, almProxy);
     }
 
     function test_initialize() public {

--- a/test/unit/OTCBuffer.t.sol
+++ b/test/unit/OTCBuffer.t.sol
@@ -67,18 +67,13 @@ contract OTCBufferInitializeTests is OTCBufferTestBase {
     }
 
     function test_initialize_cannotInitializeImplementation() public {
-        OTCBuffer newBuffer = OTCBuffer(
-            address(new OTCBuffer())
-        );
+        OTCBuffer newBuffer = new OTCBuffer();
 
         vm.expectRevert("InvalidInitialization()");
         newBuffer.initialize(admin, almProxy);
     }
 
     function test_initialize() public {
-        assertEq(buffer.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
-        assertEq(buffer.almProxy(),                         almProxy);
-
         address newAdmin = makeAddr("new-admin");
 
         OTCBuffer newBuffer = OTCBuffer(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated OTCBuffer contract to an upgradeable architecture with a proxy-based initialization pattern.
  * almProxy state variable changed from immutable to mutable for dynamic configuration.

* **Tests**
  * Updated unit and integration tests to reflect the new initialization approach and proxy deployment pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->