### PR TITLE
fix: ERC20 return data size (DEV-1147)

### DIFF
--- a/src/ForeignController.sol
+++ b/src/ForeignController.sol
@@ -201,7 +201,7 @@ contract ForeignController is ReentrancyGuard, AccessControlEnumerable {
         );
 
         require(
-            returnData.length == 0 || abi.decode(returnData, (bool)),
+            returnData.length == 0 || (returnData.length == 32 && abi.decode(returnData, (bool))),
             "FC/transfer-failed"
         );
     }
@@ -496,7 +496,10 @@ contract ForeignController is ReentrancyGuard, AccessControlEnumerable {
             // decode it first
             approveCallReturnData = abi.decode(data, (bytes));
             // Approve was successful if 1) no return value or 2) true return value
-            if (approveCallReturnData.length == 0 || abi.decode(approveCallReturnData, (bool))) {
+            if (
+                approveCallReturnData.length == 0 ||
+                (approveCallReturnData.length == 32 && abi.decode(approveCallReturnData, (bool)))
+            ) {
                 return;
             }
         }
@@ -508,7 +511,9 @@ contract ForeignController is ReentrancyGuard, AccessControlEnumerable {
 
         // Revert if approve returns false
         require(
-            approveCallReturnData.length == 0 || abi.decode(approveCallReturnData, (bool)),
+            approveCallReturnData.length == 0 ||
+            (approveCallReturnData.length == 32 && abi.decode(approveCallReturnData, (bool))
+        ),
             "FC/approve-failed"
         );
     }

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -1158,7 +1158,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
         );
 
         require(
-            returnData.length == 0 || abi.decode(returnData, (bool)),
+            returnData.length == 0 || (returnData.length == 32 && abi.decode(returnData, (bool))),
             "MC/transfer-failed"
         );
     }
@@ -1175,7 +1175,7 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
         );
 
         require(
-            returnData.length == 0 || abi.decode(returnData, (bool)),
+            returnData.length == 0 || (returnData.length == 32 && abi.decode(returnData, (bool))),
             "MC/transferFrom-failed"
         );
     }

--- a/src/libraries/ApproveLib.sol
+++ b/src/libraries/ApproveLib.sol
@@ -22,7 +22,10 @@ library ApproveLib {
             returnData = abi.decode(data, (bytes));
 
             // Approve was successful if 1) no return value or 2) true return value.
-            if (returnData.length == 0 || abi.decode(returnData, (bool))) return;
+            if (
+                returnData.length == 0 ||
+                (returnData.length == 32 && abi.decode(returnData, (bool)))
+            ) return;
         }
 
         // If call was unsuccessful, set to zero and try again.
@@ -31,7 +34,10 @@ library ApproveLib {
         returnData = IALMProxy(proxy).doCall(token, approveData);
 
         // Revert if approve returns false.
-        require(returnData.length == 0 || abi.decode(returnData, (bool)), "MC/approve-failed");
+        require(
+            returnData.length == 0 || (returnData.length == 32 && abi.decode(returnData, (bool))),
+            "MC/approve-failed"
+        );
     }
 
 }

--- a/src/libraries/UniswapV4Lib.sol
+++ b/src/libraries/UniswapV4Lib.sol
@@ -280,7 +280,8 @@ library UniswapV4Lib {
 
             // Revert if approve returns anything, and that anything is not `true`.
             require(
-                approveResult.length == 0 || abi.decode(approveResult, (bool)),
+                approveResult.length == 0 ||
+                (approveResult.length == 32 && abi.decode(approveResult, (bool))),
                 "MC/permit2-approve-failed"
             );
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of return data from external contract calls to strictly enforce proper encoding of boolean responses, ensuring only 32-byte boolean values or empty returns are accepted as valid success indicators across asset transfer and approval operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->