### PR TITLE
fix: Update `claimWithdrawal` to use `rateLimitExists` (DEV-1236)

### DIFF
--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -165,7 +165,6 @@ contract MainnetController is ReentrancyGuard, AccessControlEnumerable {
     bytes32 public LIMIT_USDE_MINT               = keccak256("LIMIT_USDE_MINT");
     bytes32 public LIMIT_USDS_MINT               = keccak256("LIMIT_USDS_MINT");
     bytes32 public LIMIT_USDS_TO_USDC            = keccak256("LIMIT_USDS_TO_USDC");
-    bytes32 public LIMIT_WEETH_CLAIM_WITHDRAW    = WEETHLib.LIMIT_WEETH_CLAIM_WITHDRAW;
     bytes32 public LIMIT_WEETH_DEPOSIT           = WEETHLib.LIMIT_WEETH_DEPOSIT;
     bytes32 public LIMIT_WEETH_REQUEST_WITHDRAW  = WEETHLib.LIMIT_WEETH_REQUEST_WITHDRAW;
     bytes32 public LIMIT_WSTETH_DEPOSIT          = keccak256("LIMIT_WSTETH_DEPOSIT");

--- a/src/libraries/WEETHLib.sol
+++ b/src/libraries/WEETHLib.sol
@@ -147,19 +147,18 @@ library WEETHLib {
     )
         external returns (uint256 ethReceived)
     {
+        // NOTE: weETHModule is enforced to be correct by the rate limit key
+        _rateLimitExists(
+            rateLimits,
+            RateLimitHelpers.makeAddressKey(LIMIT_WEETH_CLAIM_WITHDRAW, weETHModule)
+        );
+
         ethReceived =  abi.decode(
             proxy.doCall(
                 weETHModule,
                 abi.encodeCall(IWeEthModuleLike(weETHModule).claimWithdrawal, (requestId))
             ),
             (uint256)
-        );
-
-        // NOTE: weETHModule is enforced to be correct by the rate limit key
-        _rateLimited(
-            rateLimits,
-            RateLimitHelpers.makeAddressKey(LIMIT_WEETH_CLAIM_WITHDRAW, weETHModule),
-            ethReceived
         );
     }
 
@@ -169,6 +168,13 @@ library WEETHLib {
 
     function _rateLimited(IRateLimits rateLimits, bytes32 key, uint256 amount) internal {
         rateLimits.triggerRateLimitDecrease(key, amount);
+    }
+
+    function _rateLimitExists(IRateLimits rateLimits, bytes32 key) internal view {
+        require(
+            rateLimits.getRateLimitData(key).maxAmount > 0,
+            "MC/invalid-action"
+        );
     }
 
 }

--- a/src/libraries/WEETHLib.sol
+++ b/src/libraries/WEETHLib.sol
@@ -41,7 +41,6 @@ interface IWETHLike {
 
 library WEETHLib {
 
-    bytes32 public constant LIMIT_WEETH_CLAIM_WITHDRAW   = keccak256("LIMIT_WEETH_CLAIM_WITHDRAW");
     bytes32 public constant LIMIT_WEETH_DEPOSIT          = keccak256("LIMIT_WEETH_DEPOSIT");
     bytes32 public constant LIMIT_WEETH_REQUEST_WITHDRAW = keccak256("LIMIT_WEETH_REQUEST_WITHDRAW");
 
@@ -154,7 +153,7 @@ library WEETHLib {
         // NOTE: weETHModule is enforced to be correct by the rate limit key
         _rateLimitExists(
             rateLimits,
-            RateLimitHelpers.makeAddressKey(LIMIT_WEETH_CLAIM_WITHDRAW, weETHModule)
+            RateLimitHelpers.makeAddressKey(LIMIT_WEETH_REQUEST_WITHDRAW, weETHModule)
         );
 
         ethReceived =  abi.decode(

--- a/test/mainnet-fork/weETH.t.sol
+++ b/test/mainnet-fork/weETH.t.sol
@@ -349,6 +349,12 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
         mainnetController.claimWithdrawalFromWeETH(weETHModule, 1);
     }
 
+    function test_claimWithdrawalFromWeETH_failsWhenRequestRateLimitDoesNotExist() external {
+        vm.expectRevert("MC/invalid-action");
+        vm.prank(relayer);
+        mainnetController.claimWithdrawalFromWeETH(makeAddr("invalid-weETHModule"), 1);
+    }
+
     function test_claimWithdrawalFromWeETH_failsOnClaimingTwice() external {
         bytes32 depositKey         = mainnetController.LIMIT_WEETH_DEPOSIT();
         bytes32 requestWithdrawKey = RateLimitHelpers.makeAddressKey(
@@ -466,47 +472,6 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
 
         vm.prank(relayer);
         vm.expectRevert("WEETHModule/request-not-finalized");
-        mainnetController.claimWithdrawalFromWeETH(weETHModule, requestId);
-    }
-
-    function test_claimWithdrawalFromWeETH_failsWhenRequestRateLimitDoesNotExist() external {
-        bytes32 depositKey         = mainnetController.LIMIT_WEETH_DEPOSIT();
-        bytes32 requestWithdrawKey = RateLimitHelpers.makeAddressKey(
-            mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
-            weETHModule
-        );
-
-        vm.startPrank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
-        rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
-        vm.stopPrank();
-
-        deal(Ethereum.WETH, address(almProxy), 1_000e18);
-
-        uint256 minSharesOut = _getMinSharesOut(1_000e18);
-
-        vm.prank(relayer);
-        mainnetController.depositToWeETH(1_000e18, minSharesOut);
-
-        uint256 expectedEEthBalance = weETH.getEETHByWeETH(500e18);
-
-        vm.prank(relayer);
-        uint256 requestId = mainnetController.requestWithdrawFromWeETH(
-            weETHModule,
-            500e18,
-            0
-        );
-
-        IWithdrawRequestNFTLike withdrawRequestNFT = IWithdrawRequestNFTLike(liquidityPool.withdrawRequestNFT());
-
-        vm.prank(WITHDRAW_REQUEST_NFT_ADMIN);
-        IWithdrawRequestNFTLike(withdrawRequestNFT).finalizeRequests(requestId);
-
-        vm.prank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(requestWithdrawKey, 0, 0);
-
-        vm.expectRevert("MC/invalid-action");
-        vm.prank(relayer);
         mainnetController.claimWithdrawalFromWeETH(weETHModule, requestId);
     }
 

--- a/test/mainnet-fork/weETH.t.sol
+++ b/test/mainnet-fork/weETH.t.sol
@@ -355,15 +355,10 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
             mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
             weETHModule
         );
-        bytes32 claimWithdrawKey = RateLimitHelpers.makeAddressKey(
-            mainnetController.LIMIT_WEETH_CLAIM_WITHDRAW(),
-            weETHModule
-        );
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
         rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
-        rateLimits.setRateLimitData(claimWithdrawKey,   1_000e18, uint256(1_000e18) / 1 days);
         vm.stopPrank();
 
         deal(Ethereum.WETH, address(almProxy), 1_000e18);
@@ -402,15 +397,10 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
             mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
             weETHModule
         );
-        bytes32 claimWithdrawKey = RateLimitHelpers.makeAddressKey(
-            mainnetController.LIMIT_WEETH_CLAIM_WITHDRAW(),
-            weETHModule
-        );
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
         rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
-        rateLimits.setRateLimitData(claimWithdrawKey,   1_000e18, uint256(1_000e18) / 1 days);
         vm.stopPrank();
 
         deal(Ethereum.WETH, address(almProxy), 1_000e18);
@@ -447,15 +437,10 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
             mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
             weETHModule
         );
-        bytes32 claimWithdrawKey = RateLimitHelpers.makeAddressKey(
-            mainnetController.LIMIT_WEETH_CLAIM_WITHDRAW(),
-            weETHModule
-        );
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
         rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
-        rateLimits.setRateLimitData(claimWithdrawKey,   1_000e18, uint256(1_000e18) / 1 days);
         vm.stopPrank();
 
         deal(Ethereum.WETH, address(almProxy), 1_000e18);
@@ -484,6 +469,47 @@ contract MainnetControllerClaimWithdrawalFromWeETHFailureTests is MainnetControl
         mainnetController.claimWithdrawalFromWeETH(weETHModule, requestId);
     }
 
+    function test_claimWithdrawalFromWeETH_failsWhenRequestRateLimitDoesNotExist() external {
+        bytes32 depositKey         = mainnetController.LIMIT_WEETH_DEPOSIT();
+        bytes32 requestWithdrawKey = RateLimitHelpers.makeAddressKey(
+            mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
+            weETHModule
+        );
+
+        vm.startPrank(Ethereum.SPARK_PROXY);
+        rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
+        rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
+        vm.stopPrank();
+
+        deal(Ethereum.WETH, address(almProxy), 1_000e18);
+
+        uint256 minSharesOut = _getMinSharesOut(1_000e18);
+
+        vm.prank(relayer);
+        mainnetController.depositToWeETH(1_000e18, minSharesOut);
+
+        uint256 expectedEEthBalance = weETH.getEETHByWeETH(500e18);
+
+        vm.prank(relayer);
+        uint256 requestId = mainnetController.requestWithdrawFromWeETH(
+            weETHModule,
+            500e18,
+            0
+        );
+
+        IWithdrawRequestNFTLike withdrawRequestNFT = IWithdrawRequestNFTLike(liquidityPool.withdrawRequestNFT());
+
+        vm.prank(WITHDRAW_REQUEST_NFT_ADMIN);
+        IWithdrawRequestNFTLike(withdrawRequestNFT).finalizeRequests(requestId);
+
+        vm.prank(Ethereum.SPARK_PROXY);
+        rateLimits.setRateLimitData(requestWithdrawKey, 0, 0);
+
+        vm.expectRevert("MC/invalid-action");
+        vm.prank(relayer);
+        mainnetController.claimWithdrawalFromWeETH(weETHModule, requestId);
+    }
+
 }
 
 contract MainnetControllerClaimWithdrawalFromWeETHTests is MainnetControllerWeETHTestBase {
@@ -494,15 +520,10 @@ contract MainnetControllerClaimWithdrawalFromWeETHTests is MainnetControllerWeET
             mainnetController.LIMIT_WEETH_REQUEST_WITHDRAW(),
             weETHModule
         );
-        bytes32 claimWithdrawKey = RateLimitHelpers.makeAddressKey(
-            mainnetController.LIMIT_WEETH_CLAIM_WITHDRAW(),
-            weETHModule
-        );
 
         vm.startPrank(Ethereum.SPARK_PROXY);
         rateLimits.setRateLimitData(depositKey,         1_000e18, uint256(1_000e18) / 1 days);
         rateLimits.setRateLimitData(requestWithdrawKey, 1_000e18, uint256(1_000e18) / 1 days);
-        rateLimits.setRateLimitData(claimWithdrawKey,   1_000e18, uint256(1_000e18) / 1 days);
         vm.stopPrank();
 
         deal(Ethereum.WETH, address(almProxy), 1_000e18);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal rate limit validation in the withdrawal process by implementing a pre-check mechanism instead of post-execution validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->